### PR TITLE
Add `cuspcompute.md` for codim-2 cusp bifurcations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         freefem_branch: [develop, master]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install basic system dependencies
         run: |
@@ -42,7 +42,7 @@ jobs:
           echo "freefem_sha=$sha" >> $GITHUB_OUTPUT
 
       - name: Restore FreeFEM cache (by commit)
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: FreeFem-sources
           key: ${{ runner.os }}-freefem-${{ steps.get_freefem_commit.outputs.freefem_sha }}
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload test artifacts (logs)
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: ci-logs
           path: test-results/**/*

--- a/basecompute.md
+++ b/basecompute.md
@@ -65,6 +65,12 @@ else if(fileext == "fold") {
   real[int] qm, qma;
   ub[] = loadfold(fileroot, meshin, qm, qma, alpha, beta);
 }
+else if(fileext == "cusp") {
+  real[string] alpha1, alpha2;
+  real beta;
+  real[int] qm, qma;
+  ub[] = loadcusp(fileroot, meshin, qm, qma, alpha1, alpha2, beta);
+}
 else if(fileext == "hopf") {
   real omega;
   complex[string] alpha;

--- a/basecontinue.md
+++ b/basecontinue.md
@@ -79,6 +79,12 @@ if(count == 0) {
     real[int] qm, qma;
     ub[] = loadfold(fileroot, meshin, qm, qma, alpha, beta);
   }
+else if(fileext == "cusp") {
+  real[string] alpha1, alpha2;
+  real beta;
+  real[int] qm, qma;
+  ub[] = loadcusp(fileroot, meshin, qm, qma, alpha1, alpha2, beta);
+}
   else if(fileext == "hopf") {
     real omega;
     complex[string] alpha;

--- a/basedeflate.md
+++ b/basedeflate.md
@@ -71,6 +71,12 @@ else if(fileext == "fold") {
   real[int] qm, qma;
   ub[] = loadfold(fileroot, meshin, qm, qma, alpha, beta);
 }
+else if(fileext == "cusp") {
+  real[string] alpha1, alpha2;
+  real beta;
+  real[int] qm, qma;
+  ub[] = loadcusp(fileroot, meshin, qm, qma, alpha1, alpha2, beta);
+}
 else if(fileext == "hopf") {
   real omega;
   complex[string] alpha;

--- a/cuspcompute.md
+++ b/cuspcompute.md
@@ -192,6 +192,7 @@ $$
 \end{bmatrix}
 \end{equation}
 $$
+
 which similarly yields after left-multiplication by $`\begin{bmatrix}w^T & g\end{bmatrix}`$ and application of Eq. (1):
 
 $$
@@ -221,6 +222,7 @@ $$
 $$
 
 where $`\hat{w}`$ solves the non-singular system:
+
 $$
 \begin{bmatrix}
 \mathcal{J} & \mathcal{M}p_0 \\

--- a/cuspcompute.md
+++ b/cuspcompute.md
@@ -23,6 +23,12 @@ $$
 g = \left\langle{}v,\mathcal{J}w\right\rangle{} = v^T\mathcal{J}w
 $$
 
+and the cusp residual augmentation:
+
+$$
+h = \langle{}v,\mathcal{H}\left(w,w\right)\rangle = v^T\mathcal{H}\left(w,w\right)
+$$
+
 where $`g`$ is the fold residual and $`v`$ and $`w`$ are the adjoint and direct eigenvectors, respectively.
 
 $`g`$, $`v`$, and $`w`$ can be found using minimially augmented systems:
@@ -112,7 +118,7 @@ At $`g = 0`$, we have $`\mathcal{J}^Tv = 0`$ and $`(\mathcal{M}p_0)^Tv = 1`$, so
 
 It can then be confirmed that $`g = v^T\mathcal{J}w = w^T\mathcal{J}^Tv`$.
 
-Finally, the augmented cusp residual is given by:
+Finally, the augmented cusp residual can be computed directly:
 
 $$
 \begin{equation}

--- a/cuspcompute.md
+++ b/cuspcompute.md
@@ -1,0 +1,769 @@
+# cuspcompute.md
+Author: Chris Douglas ([@cmdoug](https://github.com/cmdoug)) [christopher.douglas@duke.edu](mailto:christopher.douglas@duke.edu)
+
+This script computes the normal form at a non-degenerate cusp point.
+
+The normal form is written for the real amplitude $`A`$ as:
+
+$$
+\frac{dA}{dt} + \alpha_1 \cdot \delta\lambda + \alpha_2 \cdot \delta\lambda A + \beta A^3 = 0
+$$
+
+where:
+- $`\alpha_1,\alpha_2`$ are the coefficients for the terms from parameter changes,
+- $`\delta\lambda`$ are the parameter increments,
+- $`\beta`$ is the coefficient for the term from harmonic interactions.
+
+#### RESIDUAL EVALUATION IN MINIMALLY AUGMENTED FORMULATION
+We can directly compute the residual using the varf `vR()`.
+
+To build the augmented residual `Ra`, we must additionally compute the fold residual augmentation:
+
+$$
+g = \left\langle{}v,\mathcal{J}w\right\rangle{} = v^T\mathcal{J}w
+$$
+
+where $`g`$ is the fold residual and $`v`$ and $`w`$ are the adjoint and direct eigenvectors, respectively.
+
+$`g`$, $`v`$, and $`w`$ can be found using minimially augmented systems:
+
+$$
+\begin{equation}
+\begin{bmatrix}
+-\mathcal{J} & \mathcal{M}p_0 \\
+\left(\mathcal{M}q_0\right)^T & 0
+\end{bmatrix}
+\begin{bmatrix}
+w \\
+g
+\end{bmatrix} = \begin{bmatrix}
+0 \\
+1
+\end{bmatrix}
+\end{equation}
+$$
+
+where $`q_0`$, $`p_0`$ are initial approximations of the direct & adjoint eigenvectors.
+
+This implies:
+
+$$
+\mathcal{J}w = \mathcal{M}p_0g\qquad{}\text{and}\qquad{}(\mathcal{M}q_0)^Tw = 1
+$$
+
+so
+
+$$
+w = \mathcal{J}^{-1}\mathcal{M}p_0g\qquad{}\text{and}\qquad{}g = \frac{1}{(\mathcal{M}q_0)^T\mathcal{J}^{-1}\mathcal{M}p_0}.
+$$
+
+Note that, at $`g = 0`$, we have $`\mathcal{J}w = 0`$ and $`\left(\mathcal{M}q_0\right)^Tw = 1`$.
+
+Similarly, we can find the adjoint eigenmode using the related system:
+
+$$
+\begin{bmatrix}
+v^T & g
+\end{bmatrix}\begin{bmatrix}
+-\mathcal{J} & \mathcal{M}p_0 \\
+(\mathcal{M}q_0)^T & 0
+\end{bmatrix} = \begin{bmatrix}
+0 & 1
+\end{bmatrix}
+$$
+
+This implies:
+
+$$
+v^T\mathcal{J} = g(\mathcal{M}q_0)^T\qquad{}\text{and}\qquad{}v^T\mathcal{M}p_0 = 1
+$$
+
+or, taking the transpose:
+
+$$
+\begin{equation}
+\begin{bmatrix}
+-\mathcal{J}^T & \mathcal{M}q_0 \\
+(\mathcal{M}p_0)^T & 0
+\end{bmatrix}
+\begin{bmatrix}
+v \\
+g
+\end{bmatrix} = \begin{bmatrix}
+0 \\
+1
+\end{bmatrix}
+\end{equation}
+$$
+
+giving, equivalently,
+
+$$
+\mathcal{J}^Tv = \mathcal{M}q_0g\qquad{}\text{and}\qquad{}(\mathcal{M}p_0)^Tv = 1
+$$
+
+so
+
+$$
+v = \mathcal{J}^{-T}\mathcal{M}q_0g\qquad{}\text{and}\qquad{}g = \frac{1}{(\mathcal{M}p_0)^T\mathcal{J}^{-T}\mathcal{M}q_0}
+$$
+
+At $`g = 0`$, we have $`\mathcal{J}^Tv = 0`$ and $`(\mathcal{M}p_0)^Tv = 1`$, so $`v^T\mathcal{J} = 0`$ and $`v^T\mathcal{M}p_0 = 1`$.
+
+It can then be confirmed that $`g = v^T\mathcal{J}w = w^T\mathcal{J}^Tv`$.
+
+Finally, the augmented cusp residual is given by:
+
+$$
+\begin{equation}
+h = \langle{}v,\mathcal{H}\left(w,w\right)\rangle = v^T\mathcal{H}\left(w,w\right)
+\end{equation}
+$$
+
+#### JACOBIAN CONSTRUCTION IN MINIMALLY AUGMENTED FORMULATION
+Having computed the RHS of the augmented system in `funcRa`, we now have to build the augmented Jacobian matrix for the Newton scheme:
+
+$$
+\begin{equation}
+\begin{bmatrix}
+\mathcal{J} & \frac{\partial\mathcal{J}}{\partial \lambda_1} & \frac{\partial\mathcal{J}}{\partial \lambda_2} \\
+(\frac{\partial{}g}{\partial q})^T& \frac{\partial{}g}{\partial\lambda_1} & \frac{\partial{}g}{\partial\lambda_2} \\
+(\frac{\partial{}h}{\partial q})^T& \frac{\partial{}h}{\partial\lambda_1} & \frac{\partial{}h}{\partial\lambda_2} \\
+\end{bmatrix}
+\begin{bmatrix}
+\delta{}q \\
+\delta{}\lambda_1 \\
+\delta{}\lambda_2
+\end{bmatrix} = \begin{bmatrix}
+\mathcal{R} \\
+g \\
+h
+\end{bmatrix},
+\end{equation}
+$$
+
+where $`g = v^T\mathcal{J}w`$ and $`h = v^T\mathcal{H}\left(w,w\right)`$.
+
+To determine the augmented matrix entries in the second row, we differentiate Eq. (1) along each $`z`$ in $`q, \lambda_1, \lambda_2`$ to find:
+
+$$
+\begin{equation}
+\begin{bmatrix}
+-\mathcal{J} & \mathcal{M}p_0 \\
+(\mathcal{M}q_0)^T & 0
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial w}{\partial z} \\
+\frac{\partial g}{\partial z}
+\end{bmatrix} = \begin{bmatrix}
+\frac{\partial\mathcal{J}}{\partial z}w \\
+0
+\end{bmatrix}
+\end{equation}
+$$
+
+We now left-multiply Eq. (5) by $`\begin{bmatrix}v^T & g\end{bmatrix}`$, finding due to Eq. (2) that:
+
+$$
+\frac{\partial g}{\partial z} = v^T\frac{\partial \mathcal{J}}{\partial z}w
+$$
+
+This also implies that:
+
+$$
+\mathcal{J}\frac{\partial w}{\partial z}=-\frac{\partial\mathcal{J}}{\partial z}w+\mathcal{M}p_0\frac{\partial g}{\partial z}
+$$
+
+Similarly differentiating Eq. (2), we find
+
+$$
+\begin{equation}
+\begin{bmatrix}
+-\mathcal{J}^T & \mathcal{M}q_0 \\
+(\mathcal{M}p_0)^T & 0
+\end{bmatrix}
+\begin{bmatrix}
+\frac{\partial v}{\partial z} \\
+\left(\frac{\partial g}{\partial z}\right)^T
+\end{bmatrix} = \begin{bmatrix}
+\left(
+\frac{\partial\mathcal{J}}{\partial z}\right)^Tv \\
+0
+\end{bmatrix}
+\end{equation}
+$$
+which similarly yields after left-multiplication by $`\begin{bmatrix}w^T & g\end{bmatrix}`$ and application of Eq. (1):
+
+$$
+\left(\frac{\partial g}{\partial z}\right)^T = w^T\left(\frac{\partial \mathcal{J}}{\partial z}\right)^Tv
+$$
+
+We can also find:
+
+$$
+\mathcal{J}^T\frac{\partial v}{\partial z}=-\left(\frac{\partial\mathcal{J}}{\partial z}\right)^Tv+\mathcal{M}q_0\left(\frac{\partial g}{\partial z}\right)^T
+$$
+
+To determine the augmented matrix entries in the third row, we differentiate Eq. (3) along each $`z`$ in $`q, \lambda_1, \lambda_2`$ to find:
+
+$$
+\begin{equation}
+\frac{\partial h}{\partial z} = \left(\frac{\partial v}{\partial z}\right)^T\mathcal{H}\left(w,w\right) + v^T\frac{\partial \mathcal{H}}{\partial z}\left(w,w\right) + 2v^T\mathcal{H}\left(w,\frac{\partial w}{\partial z}\right)
+\end{equation}
+$$
+
+However, it is not desirable or necessary to ever construct $`\frac{\partial w}{\partial z}`$ or $`\frac{\partial v}{\partial z}`$ explicitly. Instead of computing these dense operators, we focus on their action in the associated inner products.
+
+For the first term in Eq. (7), we have:
+
+$$
+\left(\frac{\partial v}{\partial z}\right)^T\mathcal{H}\left(w,w\right)=\left(-v^T\frac{\partial\mathcal{J}}{\partial z}+\frac{\partial g}{\partial z}\left(\mathcal{M}q_0\right)^T\right)\mathcal{J}^{-1}\mathcal{H}\left(w,w\right)=-v^T\frac{\partial\mathcal{J}}{\partial z}\hat{w}+\frac{\partial g}{\partial z}\left(\mathcal{M}q_0\right)^T\hat{w}
+$$
+
+where $`\hat{w}`$ solves the non-singular system:
+$$
+\begin{bmatrix}
+\mathcal{J} & \mathcal{M}p_0 \\
+(\mathcal{M}q_0)^T & 0
+\end{bmatrix}
+\begin{bmatrix}
+\hat{w} \\
+h
+\end{bmatrix} = \begin{bmatrix}
+\mathcal{H}\left(w,w\right) \\
+0
+\end{bmatrix}
+$$
+
+giving equivalently,
+
+$$
+\mathcal{J}\hat{w}=\mathcal{H}\left(w,w\right)-\mathcal{M}p_0h\qquad{}\text{and}\qquad{}(\mathcal{M}q_0)^T\hat{w}=0
+$$
+
+so, using the identities derived above that $`w=\mathcal{J}^{-1}\mathcal{M}p_0g`$ and $`v=\mathcal{J}^{-T}\mathcal{M}q_0g`$,
+
+$$
+\hat{w}=\mathcal{J}^{-1}\mathcal{H}\left(w,w\right)-w\frac{h}{g}\qquad{}\text{and}\qquad{}h=v^T\mathcal{H}\left(w,w\right)
+$$
+
+Then, similarly, for the last term in Eq. (7), we have:
+
+$$
+2v^T\mathcal{H}\left(w,\frac{\partial w}{\partial z}\right)=2v^T\mathcal{H}\left(w, \cdot\right)\mathcal{J}^{-1}\left(-\frac{\partial\mathcal{J}}{\partial z}w+\mathcal{M}p_0\frac{\partial g}{\partial z}\right)=-2\hat{v}^T\frac{\partial\mathcal{J}}{\partial z}w+2\hat{v}^T\mathcal{M}p_0\frac{\partial g}{\partial z}
+$$
+
+where $`\hat{v}`$ solves the non-singular system:
+
+$$
+\begin{bmatrix}
+\mathcal{J}^T & \mathcal{M}q_0 \\
+(\mathcal{M}p_0)^T & 0
+\end{bmatrix}
+\begin{bmatrix}
+\hat{v} \\
+h
+\end{bmatrix} = \begin{bmatrix}
+\mathcal{H}\left(w,\cdot\right)^Tv \\
+0
+\end{bmatrix}
+$$
+
+giving equivalently,
+
+$$
+\mathcal{J}^T\hat{v}=\mathcal{H}\left(w,\cdot\right)^Tv-\mathcal{M}q_0h\qquad{}\text{and}\qquad{}(\mathcal{M}p_0)^T\hat{v}=0
+$$
+
+so, using the identities derived above that $`w=\mathcal{J}^{-1}\mathcal{M}p_0g`$ and $`v=\mathcal{J}^{-T}\mathcal{M}q_0g`$,
+
+$$
+\hat{v}=\mathcal{J}^{-T}\left(\mathcal{H}\left(w,\cdot\right)^Tv\right)-v\frac{h}{g}\qquad{}\text{and}\qquad{}h=\mathcal{H}\left(w,w\right)^Tv
+$$
+
+So we can write Eq. (4) explicitly as
+
+$$
+\begin{bmatrix}
+\mathcal{J} & \frac{\partial\mathcal{J}}{\partial \lambda_1} & \frac{\partial\mathcal{J}}{\partial \lambda_2} \\
+v^T\frac{\partial \mathcal{J}}{\partial q}w & v^T\frac{\partial \mathcal{J}}{\partial \lambda_1}w & v^T\frac{\partial \mathcal{J}}{\partial \lambda_2}w \\
+\frac{\partial h}{\partial q} & \frac{\partial h}{\partial \lambda_1} & \frac{\partial h}{\partial \lambda_2}
+\end{bmatrix}
+\begin{bmatrix}
+\delta{}q \\
+\delta\lambda_1 \\
+\delta\lambda_2
+\end{bmatrix} = \begin{bmatrix}
+\mathcal{R} \\
+g \\
+h
+\end{bmatrix}
+$$
+
+where
+
+$$
+\frac{\partial h}{\partial z} = -v^T\frac{\partial\mathcal{J}}{\partial z}\hat{w} + v^T\frac{\partial \mathcal{H}}{\partial z}\left(w,w\right) - 2\hat{v}^T\frac{\partial\mathcal{J}}{\partial z}w + \left(\left(\mathcal{M}q_0\right)^T\hat{w}+2\hat{v}^T\mathcal{M}p_0\right)\frac{\partial g}{\partial z}
+$$
+
+## EXAMPLE USAGE:
+### Initialize with fold guess from base file, solve on same mesh
+```sh
+ff-mpirun -np 4 cuspcompute.md -param <PARAM> -param2 <PARAM2> -fi <FILEIN> -fo <FILEOUT>
+```
+
+### Initialize with fold from fold file, solve on same mesh
+```sh
+ff-mpirun -np 4 cuspcompute.md -param <PARAM> -param2 <PARAM2> -fi <FILEIN> -fo <FILEOUT>
+```
+
+### Initialize with fold guess from file on a mesh from file
+```sh
+ff-mpirun -np 4 cuspcompute.md -param <PARAM> -param2 <PARAM2> -mi <MESHIN> -fi <FILEIN> -fo <FILEOUT>
+```
+
+### Initialize with fold from file, adapt mesh/solution
+```sh
+ff-mpirun -np 4 cuspcompute.md -param <PARAM> -param2 <PARAM2> -fi <FILEIN> -fo <FILEOUT> -mo <MESHOUT>
+```
+
+NOTE: This file should not be changed unless you know what you're doing.
+
+SEE ALSO: [modecompute.md](./modecompute.md), [basecontinue.md](./basecontinue.md), [foldcompute.md](./foldcompute.md), [foldcontinue.md](./foldcontinue.md), [hopfcontinue.md](./hopfcontinue.md), [fohocompute.md](./fohocompute.md)
+
+```freefem
+load "iovtk"
+load "PETSc"
+include "settings.idp"
+include "macros_bifbox.idp"
+// arguments
+string meshin = getARGV("-mi", "");
+string meshout = getARGV("-mo", "");
+string filein = getARGV("-fi", "");
+string fileout = getARGV("-fo", "");
+bool normalform = getARGV("-nf", 1);
+bool wnlsave = getARGV("-wnl", 0);
+string param = getARGV("-param", "");
+string param2 = getARGV("-param2", "");
+string adaptto = getARGV("-adaptto", "b");
+real eps = getARGV("-eps", 1e-7);
+real eps2 = getARGV("-eps2", 1e-7);
+real TGV = getARGV("-tgv", -1);
+string sneslinesearchtype = getARGV("-snes_linesearch_type", "none");
+real[string] alpha1;
+real[string] alpha2;
+real beta;
+
+// Load mesh, make FE basis
+string fileroot, fileext = parsefilename(filein, fileroot); //extract file name and extension
+parsefilename(fileout, fileout); // trim extension from output file, if given
+if(fileext == "mode" || fileext == "resp" || fileext == "rslv" || fileext == "tdls" || fileext == "floq") {
+  filein = readbasename(workdir + filein);
+  fileext = parsefilename(filein, fileroot);
+}
+if(meshin == "") meshin = readmeshname(workdir + filein); // get mesh file
+string meshroot, meshext = parsefilename(meshin, meshroot);
+parsefilename(meshout, meshout); // trim extension from output mesh, if given
+Th = readmeshN(workdir + meshin);
+Thg = Th;
+DmeshCreate(Th);
+restu = restrict(XMh, XMhg, n2o);
+XMh defu(ub), defu(um), defu(uma), defu(um2), defu(um3);
+// Initialize solution with guess or file
+if(fileext == "base") {
+  ub[] = loadbase(fileroot, meshin);
+}
+else if(fileext == "fold") {
+  ub[] = loadfold(fileroot, meshin, um[], uma[], alpha1, beta);
+}
+else if(fileext == "cusp") {
+  ub[] = loadcusp(fileroot, meshin, um[], uma[], alpha1, alpha2, beta);
+}
+else if(fileext == "foho") {
+  real omega, beta23, gamma22, gamma23;
+  complex[string] alpha2;
+  complex beta1, gamma12, gamma13;
+  complex[int] q1m, q1ma;
+  ub[] = loadfoho(fileroot, meshin, q1m, q1ma, um[], uma[], sym, omega, alpha2, alpha1, beta1, beta, beta23, gamma12, gamma13, gamma22, gamma23);
+}
+else if(fileext == "hopf") {
+  real omega;
+  complex[string] alpha;
+  complex beta;
+  complex[int] qm, qma;
+  ub[] = loadhopf(fileroot, meshin, qm, qma, sym, omega, alpha, beta);
+}
+else if(fileext == "hoho") {
+  real[int] sym1(sym.n), sym2(sym.n);
+  real omega1, omega2;
+  complex[string] alpha1, alpha2;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
+  complex[int] q1m, q1ma, q2m, q2ma;
+  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
+}
+else if(fileext == "tdns") {
+  real time;
+  ub[] = loadtdns(fileroot, meshin, time);
+}
+else if(fileext == "porb") {
+  int Nh=1;
+  real omega;
+  complex[int, int] qh(um[].n, Nh);
+  ub[] = loadporb(fileroot, meshin, qh, sym, omega, Nh);
+}
+real[int] paramvals(2);
+paramvals(0) = getparam(param);
+paramvals(1) = getparam(param2);
+// Create distributed Mat
+Mat J;
+createMatu(Th, J, Pk);
+// MESH ADAPTATION
+bool adapt = false;
+if(meshout == "") meshout = meshin; // if no adaptation
+else { // if output meshfile is given, adapt mesh
+  adapt = true;
+  meshout = meshout + "." + meshext;
+  real[int] q;
+  ChangeNumbering(J, ub[], q);
+  ChangeNumbering(J, ub[], q, inverse = true);
+  ChangeNumbering(J, um[], q);
+  ChangeNumbering(J, um[], q, inverse = true);
+  ChangeNumbering(J, uma[], q);
+  ChangeNumbering(J, uma[], q, inverse = true);
+  XMhg defu(uG), defu(umG), defu(umaG), defu(tempu), defu(uoG); // create private global FE functions
+  tempu[](restu) = ub[]; // populate local portion of global soln
+  mpiAllReduce(tempu[], uG[], mpiCommWorld, mpiSUM); //aggregate local solns into global soln
+  tempu[](restu) = um[]; // populate local portion of global soln
+  mpiAllReduce(tempu[], umG[], mpiCommWorld, mpiSUM); //aggregate local solns into global soln
+  tempu[](restu) = uma[]; // populate local portion of global soln
+  mpiAllReduce(tempu[], umaG[], mpiCommWorld, mpiSUM); //aggregate local solns into global soln
+  if(mpirank == 0) {  // Perform mesh adaptation (serially) on processor 0
+    if(adaptto == "bo") {
+      defu(tempu) = initu(defu(umaG)'*defu(umaG));
+      tempu[] = sqrt(tempu[]);
+      uoG[] = (umG[].*umG[]);
+      uoG[] = sqrt(uoG[]);
+      uoG[] .*= tempu[];
+    }
+    IFMACRO(dimension,2)
+      if(adaptto == "b") Thg = adaptmesh(Thg, adaptu(uG), adaptmeshoptions);
+      else if(adaptto == "bd") Thg = adaptmesh(Thg, adaptu(uG), adaptu(umG), adaptmeshoptions);
+      else if(adaptto == "ba") Thg = adaptmesh(Thg, adaptu(uG), adaptu(umaG), adaptmeshoptions);
+      else if(adaptto == "bda") Thg = adaptmesh(Thg, adaptu(uG), adaptu(umG), adaptu(umaG), adaptmeshoptions);
+      else if(adaptto == "bo") Thg = adaptmesh(Thg, adaptu(uG), adaptu(uoG), adaptmeshoptions);
+    ENDIFMACRO
+    IFMACRO(dimension,3)
+      //NOTE: 3D mesh adaptation is still under development.
+      load "mshmet"
+      load "mmg"
+      real anisomax = getARGV("-anisomax",1.0);
+      real[int] met((bool(anisomax > 1) ? 6 : 1)*Thg.nv);
+      if(adaptto == "b") met = mshmet(Thg, adaptu(uG), normalization = getARGV("-normalization",1), aniso = bool(anisomax > 1.0),hmin = getARGV("-hmin", 1.0e-6), hmax = getARGV("-hmax", 1.0e+2), err = getARGV("-err", 1.0e-2));
+      else if(adaptto == "bd") met = mshmet(Thg, adaptu(uG), adaptu(umG), normalization = getARGV("-normalization",1), aniso = bool(anisomax > 1.0),hmin = getARGV("-hmin", 1.0e-6), hmax = getARGV("-hmax", 1.0e+2), err = getARGV("-err", 1.0e-2));
+      else if(adaptto == "ba") met = mshmet(Thg, adaptu(uG), adaptu(umaG), normalization = getARGV("-normalization",1), aniso = bool(anisomax > 1.0),hmin = getARGV("-hmin", 1.0e-6), hmax = getARGV("-hmax", 1.0e+2), err = getARGV("-err", 1.0e-2));
+      else if(adaptto == "bda") met = mshmet(Thg, adaptu(uG), adaptu(umG), adaptu(umaG), normalization = getARGV("-normalization",1), aniso = bool(anisomax > 1.0),hmin = getARGV("-hmin", 1.0e-6), hmax = getARGV("-hmax", 1.0e+2), err = getARGV("-err", 1.0e-2));
+      else if(adaptto == "bo") met = mshmet(Thg, adaptu(uG), adaptu(uoG), normalization = getARGV("-normalization",1), aniso = bool(anisomax > 1.0),hmin = getARGV("-hmin", 1.0e-6), hmax = getARGV("-hmax", 1.0e+2), err = getARGV("-err", 1.0e-2));
+      if(anisomax > 1.0) {
+        load "aniso"
+        boundaniso(6, met, anisomax);
+      }
+      Thg = mmg3d(Thg, metric = met, hmin = getARGV("-hmin", 1.0e-6), hmax = getARGV("-hmax", 1.0e+2), hgrad = -1, verbose = verbosity-(verbosity==0));
+    ENDIFMACRO
+  }
+  broadcast(processor(0), Thg); // broadcast global mesh to all processors
+  defu(uG) = defu(uG); //interpolate global solution from old mesh to new mesh
+  defu(umG) = defu(umG); //interpolate global solution from old mesh to new mesh
+  defu(umaG) = defu(umaG); //interpolate global solution from old mesh to new mesh
+  Th = Thg; //Reinitialize local mesh with global mesh
+  Mat Adapt; // Partition new mesh and update the PETSc numbering
+  createMatu(Th, Adapt, Pk);
+  J = Adapt;
+  defu(ub) = initu(0.0); // set local values to zero
+  defu(um) = initu(0.0); // set local values to zero
+  defu(uma) = initu(0.0); // set local values to zero
+  defu(um2) = initu(0.0);
+  defu(um3) = initu(0.0);
+  restu.resize(ub[].n); // Change size of restriction operator
+  restu = restrict(XMh, XMhg, n2o); // Compute new restriction from global mesh to local mesh
+  ub[] = uG[](restu); //restrict global solution to each local mesh
+  um[] = umG[](restu); //restrict global solution to each local mesh
+  uma[] = umaG[](restu); //restrict global solution to each local mesh
+}
+// Build bordered block matrix from only Mat components
+sym = 0;
+real[int] ik(sym.n), ik2(sym.n), ik3(sym.n);
+real iomega = 0.0, iomega2 = 0.0, iomega3 = 0.0;
+include "eqns.idp"
+Mat JlPM(J.n, mpirank == 0 ? 2 : 0), gqPM(J.n, mpirank == 0 ? 2 : 0), glPM(mpirank == 0 ? 2 : 0, mpirank == 0 ? 2 : 0); // Initialize Mat objects for bordered matrix
+Mat H(J), Ja = [[J, JlPM], [gqPM', glPM]]; // make dummy Jacobian
+real[int] R(ub[].n), qm(J.n), qma(J.n), qpm(J.n), qpma(J.n), pP(J.n), qP(J.n);
+real h, ginv;
+// FUNCTIONS
+  func real[int] funcRa(real[int]& qa) {
+      ChangeNumbering(J, ub[], qa(0:J.n-1), inverse = true, exchange = true); // PETSc to FreeFEM
+      if(mpirank == 0) paramvals = qa(J.n:Ja.n-1); // Extract parameter value from state vector on proc 0
+      broadcast(processor(0), paramvals);
+      updateparam(param, paramvals(0));
+      updateparam(param2, paramvals(1));
+      R = vR(0, XMh, tgv = TGV);
+      real[int] Ra;
+      ChangeNumbering(J, R, Ra); // FreeFEM to PETSc
+      J = vJ(XMh, XMh, tgv = -2);
+      KSPSolve(J, pP, qm);
+      KSPSolveTranspose(J, qP, qma);
+      real ginvl = (qP'*qm);
+      mpiAllReduce(ginvl, ginv, mpiCommWorld, mpiSUM);
+      qm /= ginv;
+      qma /= ginv;
+      ChangeNumbering(J, um[], qm, inverse = true, exchange = true);
+      ChangeNumbering(J, uma[], qma, inverse = true);
+      um2[] = um[];
+      um3[] = vH(0, XMh, tgv = -10);
+      h = J(uma[], um3[]);      
+      Ra.resize(Ja.n); // Append 0 to residual vector on proc 0
+      if(mpirank == 0) Ra(J.n:Ja.n-1) = [1.0/ginv, h];
+      return Ra;
+  }
+
+  func int funcJa(real[int]& qa) {
+      ChangeNumbering(J, ub[], qa(0:J.n-1), inverse = true, exchange = true); // PETSc to FreeFEM
+      if(mpirank == 0) paramvals = qa(J.n:Ja.n-1); // Extract parameter value from state vector on proc 0
+      broadcast(processor(0), paramvals);
+      real[int] temp1, temp3;
+      ChangeNumbering(J, um3[], qpm);
+      KSPSolve(J, qpm, qpm);
+      qpm -= h*ginv*qm;
+      H = vH(XMh, XMh, tgv = 0);
+      MatMultTranspose(H, qma, temp3);
+      KSPSolveTranspose(J, temp3, qpma);
+      qpma -= h*ginv*qma;
+      qpma *= 2.0;
+      updateparam(param, paramvals(0) + eps);
+      updateparam(param2, paramvals(1));
+      real[int] Jl = vR(0, XMh, tgv = TGV);
+      real[int] Hl1 = vJ(0, XMh, tgv = -10);
+      real[int] Tl1 = vH(0, XMh, tgv = -10);
+      ChangeNumbering(J, um[], qpm, inverse = true, exchange = true);
+      um3[] = vJ(0, XMh, tgv = -10);
+      Tl1 -= um3[];
+      updateparam(param, paramvals(0));
+      um3[] = vJ(0, XMh, tgv = -10);
+      Tl1 += um3[];
+      ChangeNumbering(J, um[], qm, inverse = true, exchange = true);
+      Jl -= R;
+      Jl /= eps;
+      ChangeNumbering(J, Jl, temp1); // FreeFEM to PETSc
+      um3[] = vJ(0, XMh, tgv = -10);
+      Hl1 -= um3[];
+      um3[] = vH(0, XMh, tgv = -10);
+      Tl1 -= um3[];
+      updateparam(param2, paramvals(1) + eps2);
+      Jl = vR(0, XMh, tgv = TGV);
+      real[int] Hl2 = vJ(0, XMh, tgv = -10);
+      real[int] Tl2 = vH(0, XMh, tgv = -10);
+      ChangeNumbering(J, um[], qpm, inverse = true, exchange = true);
+      um3[] = vJ(0, XMh, tgv = -10);
+      Tl2 -= um3[];
+      updateparam(param2, paramvals(1));
+      um3[] = vJ(0, XMh, tgv = -10);
+      Tl2 += um3[];
+      ChangeNumbering(J, um[], qm, inverse = true, exchange = true);
+      Jl -= R;
+      Jl /= eps2;
+      ChangeNumbering(J, Jl, qm); // FreeFEM to PETSc
+      matrix tempPms = [[temp1, qm]]; // dense array to sparse matrix
+      ChangeOperator(JlPM, tempPms, parent = Ja); // send to Mat
+      um3[] = vJ(0, XMh, tgv = -10);
+      Hl2 -= um3[];
+      um3[] = vH(0, XMh, tgv = -10);
+      Tl2 -= um3[];
+      MatMultTranspose(H, qpma, qm);
+      qm *= -1.0;
+      IFMACRO(cubic)
+      H = vT(XMh, XMh, tgv = 0);
+      MatMultTranspose(H, qma, temp1);
+      qm += temp1;
+      ENDIFMACRO
+      ChangeNumbering(J, um[], qpm, inverse = true, exchange = true);
+      H = vH(XMh, XMh, tgv = 0);
+      MatMultTranspose(H, qma, temp1);
+      qm -= temp1;
+      real tt, ttl = (qP'*qpm) + (qpma'*pP);
+      mpiAllReduce(ttl, tt, mpiCommWorld, mpiSUM);
+      qm += tt*temp3;
+      tempPms = [[temp3, qm]]; // dense array to sparse matrix
+      ChangeOperator(gqPM, tempPms, parent = Ja); // send to Mat
+      real gl1 = J(uma[], Hl1)/eps;
+      real gl2 = J(uma[], Hl2)/eps2;
+      ChangeNumbering(J, um3[], qpma, inverse = true);
+      real hl1 = (J(uma[], Tl1) - J(um3[], Hl1))/eps + tt*gl1;
+      real hl2 = (J(uma[], Tl2) - J(um3[], Hl2))/eps2 + tt*gl2;
+      tempPms = [[gl1, gl2],
+                 [hl1, hl2]];
+      ChangeOperator(glPM, tempPms, parent = Ja); // send to Mat
+      J = vJ(XMh, XMh, tgv = TGV);
+      return 0;
+  }
+// set up Mat parameters
+IFMACRO(Jprecon) Jprecon(0); ENDIFMACRO
+set(Ja, sparams = "-ksp_type preonly -pc_type fieldsplit -pc_fieldsplit_type schur -pc_fieldsplit_schur_precondition full"
+                + " -prefix_push fieldsplit_1_ -ksp_type preonly -pc_type redundant -redundant_pc_type lu -prefix_pop"
+                + " -prefix_push fieldsplit_0_ " + KSPparams + " -prefix_pop", setup = 1);
+set(J, IFMACRO(Jsetargs) Jsetargs, ENDIFMACRO prefix = "fieldsplit_0_", parent = Ja);
+// Initialize
+real[int] qa;
+ChangeNumbering(J, ub[], qa);
+qa.resize(Ja.n);
+if(mpirank == 0) qa(J.n:Ja.n-1) = paramvals;
+if (fileext != "fold" && fileext != "foho"){
+  updateparam(param, paramvals(0) + eps);
+  um2[] = vR(0, XMh);
+  updateparam(param, paramvals(0));
+  R = vR(0, XMh);
+  um2[] -= R;
+  um2[] /= eps;
+  J = vJ(XMh, XMh);
+  um[] = J^-1*um2[];
+  uma[] = J'^-1*um2[];
+}
+um2[] = vM(0, XMh, tgv = 0);
+ChangeNumbering(J, um[], qm);
+ChangeNumbering(J, um[], qm, inverse = true);
+real Mnorm = sqrt(J(um[], um2[]));
+um2[] /= Mnorm;
+ChangeNumbering(J, um2[], qP);
+ChangeNumbering(J, uma[], qma);
+ChangeNumbering(J, um[], qma, inverse = true, exchange = true);
+um2[] = vM(0, XMh, tgv = 0);
+ChangeNumbering(J, um[], qm, inverse = true);
+um2[] *= (Mnorm/J(um[], um2[])); // so that <uma[],M*um[]> = 1
+ChangeNumbering(J, um2[], pP);
+// solve nonlinear problem with SNES
+int ret;
+SNESSolve(Ja, funcJa, funcRa, qa, reason = ret,
+          sparams = "-snes_linesearch_type " + sneslinesearchtype + " -options_left no -snes_monitor -snes_converged_reason");
+if (ret > 0) { // Save solution if solver converged and output file is given
+  ChangeNumbering(J, ub[], qa(0:J.n-1), inverse = true, exchange = true);
+  if(mpirank == 0) paramvals = qa(J.n:Ja.n-1);
+  broadcast(processor(0), paramvals);
+  updateparam(param, paramvals(0));
+  updateparam(param2, paramvals(1));
+  ChangeNumbering(J, um[], qm, inverse = true, exchange = true);
+  um2[] = vM(0, XMh, tgv = 0);
+  ChangeNumbering(J, um[], qm, inverse = true);
+  ChangeNumbering(J, uma[], qma, inverse = true);
+  Mnorm = sqrt(J(um[], um2[]));
+  um[] /= Mnorm; // so that <um[],M*um[]> = 1
+  uma[] *= (Mnorm/J(uma[], um2[])); // so that <uma[],M*um[]> = 1
+  ChangeNumbering(J, um[], qm);
+  ChangeNumbering(J, uma[], qma);
+  if (normalform){
+    real[int,int] qDa(paramnames.n, J.n);
+    Mat qPM(J.n, mpirank == 0 ? 1 : 0), pPM(J.n, mpirank == 0 ? 1 : 0); // Initialize Mat objects for bordered matrix
+    Ja = [[J, qPM], [pPM', 0]]; // make dummy Jacobian
+    set(Ja, sparams = "-ksp_type preonly -pc_type fieldsplit -pc_fieldsplit_type schur -pc_fieldsplit_schur_precondition full"
+                    + " -prefix_push fieldsplit_1_ -ksp_type preonly -pc_type redundant -redundant_pc_type lu -prefix_pop"
+                    + " -prefix_push fieldsplit_0_ " + KSPparams + " -prefix_pop", setup = 1);
+    // 2nd-order
+    //  A: base modification due to parameter changes
+    ChangeNumbering(J, um[], qma, inverse = true, exchange = true);
+    um2[] = vM(0, XMh, tgv = -10);
+    ChangeNumbering(J, um2[], pP);
+    matrix tempPms = [[pP]]; // dense array to sparse matrix
+    ChangeOperator(pPM, tempPms, parent = Ja); // send to Mat
+    ChangeNumbering(J, um[], qm, inverse = true, exchange = true);
+    um2[] = vM(0, XMh, tgv = -10);
+    ChangeNumbering(J, um2[], qP);
+    tempPms = [[qP]]; // dense array to sparse matrix
+    ChangeOperator(qPM, tempPms, parent = Ja); // send to Mat
+    J = vJ(XMh, XMh, tgv = TGV);
+    ChangeNumbering(J, uma[], qma, inverse = true);
+    if(paramnames[0] != ""){
+      for (int k = 0; k < paramnames.n; ++k){
+        real paramval = getparam(paramnames[k]);
+        updateparam(paramnames[k], paramval + eps);
+        um2[] = vR(0, XMh, tgv = TGV);
+        updateparam(paramnames[k], paramval);
+        um2[] -= R;
+        um2[] /= -eps;
+        ChangeNumbering(J, um2[], qP); // FreeFEM to PETSc
+        qP.resize(Ja.n);
+        if(mpirank == 0) qP(Ja.n-1) = 0.0;
+        KSPSolve(Ja, qP, qP);
+        if(mpirank == 0) alpha1[paramnames[k]] = -qP(Ja.n-1);
+        broadcast(processor(0), alpha1[paramnames[k]]);
+        qDa(k, :) = qP(0:J.n-1);
+      }
+    }
+    //  B: base modifications due to quadratic nonlinear interactions
+    um2[] = -0.5*um[];
+    um3[] = vH(0, XMh, tgv = -10);
+    ChangeNumbering(J, um3[], pP); // FreeFEM to PETSc
+    pP.resize(Ja.n);
+    if(mpirank == 0) pP(Ja.n-1) = 0.0;
+    KSPSolve(Ja, pP, pP);
+    pP.resize(J.n);
+    // 3rd-order
+    //  A: base modification due to parameter changes
+    if(paramnames[0] != ""){
+      R = vJ(0, XMh, tgv = -10);
+      for (int k = 0; k < paramnames.n; ++k){
+        ChangeNumbering(J, um2[], qDa(k, :), inverse = true, exchange = true);
+        um3[] = vH(0, XMh, tgv = -10);
+        real paramval = getparam(paramnames[k]);
+        updateparam(paramnames[k], paramval + eps);
+        um2[] = vJ(0, XMh, tgv = -10);
+        updateparam(paramnames[k], paramval);
+        um2[] -= R;
+        um3[] += um2[]/eps;
+        alpha2[paramnames[k]] = J(uma[], um3[]);
+      }
+    }
+    //  B: base modification due to quadratic nonlinear interaction
+    IFMACRO(cubic)
+    um2[] = um[];
+    um3[] = um[]/3.0;
+    R = vT(0, XMh, tgv = -10);
+    ENDIFMACRO
+    //  C: fundamental modification due to quadratic interaction of fundamental with 2nd order modification B
+    ChangeNumbering(J, um2[], pP, inverse = true, exchange = true); // FreeFEM to PETSc
+    IFMACRO(cubic)
+    um3[] = vH(0, XMh, tgv = -10);
+    R += um3[];
+    ENDIFMACRO
+    IFMACRO(!cubic)
+    R = vH(0, XMh, tgv = -10);
+    ENDIFMACRO
+    beta = 0.5*J(uma[], R);
+    if(wnlsave){
+      complex[int] val(1);
+      XMh<complex>[int] defu(vec)(1);
+      XMh<complex> defu(um);
+      if(paramnames[0] != ""){
+        for (int k = 0; k < paramnames.n; ++k){
+          ChangeNumbering(J, um2[], qDa(k, :), inverse = true);
+          vec[0][].re = um2[];
+          savemode(fileout + "_wnl_param" + k, "", fileout + ".cusp", meshout, vec, val, sym, true);
+        }
+      }
+      ChangeNumbering(J, um2[], pP, inverse = true);
+      vec[0][].re = um2[];
+      savemode(fileout + "_wnl_AA", "", fileout + ".cusp", meshout, vec, val, sym, true);
+    }
+  }
+  else {
+    for (int k = 0; k < paramnames.n; ++k){
+      alpha1[paramnames[k]] = 0.0;
+      alpha2[paramnames[k]] = 0.0;
+    }
+    beta = 0.0;
+  }
+  if(mpirank==0 && adapt) { // Save adapted mesh
+    cout << "  Saving adapted mesh '" + meshout + "' in '" + workdir + "'." << endl;
+    savemesh(Thg, workdir + meshout);
+  }
+  ChangeNumbering(J, ub[], qa(0:J.n-1), inverse = true);
+  ChangeNumbering(J, um[], qm, inverse = true);
+  savecusp(fileout, "", meshout, alpha1, alpha2, beta, true, true);
+}
+```

--- a/examples/douglas_2024/basecomputeaug.md
+++ b/examples/douglas_2024/basecomputeaug.md
@@ -65,6 +65,12 @@ else if(fileext == "fold") {
   real[int] qm, qma;
   ub[] = loadfold(fileroot, meshin, qm, qma, alpha, beta);
 }
+else if(fileext == "cusp") {
+  real[string] alpha1, alpha2;
+  real beta;
+  real[int] qm, qma;
+  ub[] = loadcusp(fileroot, meshin, qm, qma, alpha1, alpha2, beta);
+}
 else if(fileext == "hopf") {
   real omega;
   complex[string] alpha;

--- a/examples/douglas_2024/modecomputeaug.md
+++ b/examples/douglas_2024/modecomputeaug.md
@@ -67,6 +67,12 @@ else if(fileext == "fold") {
   real[int] qm, qma;
   ub[] = loadfold(fileroot, meshin, qm, qma, alpha, beta);
 }
+else if(fileext == "cusp") {
+  real[string] alpha1, alpha2;
+  real beta;
+  real[int] qm, qma;
+  ub[] = loadcusp(fileroot, meshin, qm, qma, alpha1, alpha2, beta);
+}
 else if(fileext == "hopf") {
   real omega;
   complex[string] alpha;

--- a/examples/douglas_etal_2021/README.md
+++ b/examples/douglas_etal_2021/README.md
@@ -114,57 +114,63 @@ ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi swirljet100_F.fold -f
 ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi swirljet100_B.fold -fo swirljet -mo swirljetfold -adaptto bda -thetamax 1 -param 1/Re -param2 S -h0 4 -scount 4 -maxcount 32
 ```
 
+8. Compute the codimension-2 cusp bifurcation along the fold curve with mesh adaptation
+```sh
+cd "$workdir" && set -- swirljet_*specialpt.fold && export C="$1" && cd -
+ff-mpirun -np $nproc cuspcompute.md -v 0 -dir $workdir -fi $C -fo swirljet -mo swirljetcusp -adaptto bda -thetamax 1 -param 1/Re -param2 S -nf 1
+```
+
 ### Bifurcations to unsteady, 3D dynamics
-8. Compute base state at $Re=133$, $S=1.8$ with guess from $Re=100$ continuation along $S$
+9. Compute base state at $Re=133$, $S=1.8$ with guess from $Re=100$ continuation along $S$
 ```sh
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi swirljet100_10.base -fo swirljet1p8 -1/Re 0.0075 -S 1.8
 ```
 
-9. Compute leading $|m|=1$ and $|m|=2$ eigenvalues
+10. Compute leading $|m|=1$ and $|m|=2$ eigenvalues
 ```sh
 ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi swirljet1p8.base -fo swirljet1p8m1 -eps_target 0.1-0.8i -sym -1 -eps_pos_gen_non_hermitian
 ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi swirljet1p8.base -fo swirljet1p8m2 -eps_target 0.1+0.4i -sym -2 -eps_pos_gen_non_hermitian
 ```
 
-10. Compute Hopf bifurcation points
+11. Compute Hopf bifurcation points
 ```sh
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi swirljet1p8m1.mode -fo swirljetm1 -param 1/Re -nf 0
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi swirljet1p8m2.mode -fo swirljetm2 -param 1/Re -nf 0
 ```
 
-11. Adapt the mesh to the critical base/direct/adjoint solutions, save `.vtu` files for ParaView
+12. Adapt the mesh to the critical base/direct/adjoint solutions, save `.vtu` files for ParaView
 ```sh
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi swirljetm1.hopf -fo swirljetm1 -param 1/Re -mo swirljetm1 -adaptto bda -pv 1 -thetamax 1
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi swirljetm2.hopf -fo swirljetm2 -param 1/Re -mo swirljetm2 -adaptto bda -pv 1 -thetamax 1
 ```
 
-12. Continue the neutral Hopf curves in the $(1/Re,S)$-plane with adaptive remeshing
+13. Continue the neutral Hopf curves in the $(1/Re,S)$-plane with adaptive remeshing
 ```sh
 ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi swirljetm1.hopf -fo swirljetm1 -mo swirljetm1hopf -adaptto bda -thetamax 1 -param 1/Re -param2 S -h0 4 -scount 4 -maxcount 32
 ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi swirljetm2.hopf -fo swirljetm2 -mo swirljetm2hopf -adaptto bda -thetamax 1 -param 1/Re -param2 S -h0 4 -scount 4 -maxcount 12
 ```
 
-13. Compute the Hopf-Hopf point where the $|m|=1$ and $|m|=2$ curves cross
+14. Compute the Hopf-Hopf point where the $|m|=1$ and $|m|=2$ curves cross
 ```sh
 ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fi swirljetm2.hopf -fi2 swirljetm1.hopf -fo swirljetm2m1 -param 1/Re -param2 S -nf 0
 ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fi swirljetm2m1.hoho -fo swirljetm2m1 -param 1/Re -param2 S -mo swirljetm2m1 -adaptto bda -pv 1 -thetamax 1
 ```
 
-14. Compute the fold-Hopf point where the $|m|=1$ curve intersects the fold curve
+15. Compute the fold-Hopf point where the $|m|=1$ curve intersects the fold curve
 ```sh
 cd "$workdir" && set -- swirljetm1_*specialpt.hopf && export fohoguess="$2" && cd -
 ff-mpirun -np $nproc fohocompute.md -v 0 -dir $workdir -fi $fohoguess -fo swirljetm1 -param S -param2 1/Re -snes_divergence_tolerance 1e10
 ```
 
 ### Periodic 3D dynamics
-15. Continue periodic solutions along $S$ from their initial Hopf points using the harmonic balance method with $N_h=2$.
+16. Continue periodic solutions along $S$ from their initial Hopf points using the harmonic balance method with $N_h=2$.
 ```sh
 ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi swirljetm1.hopf -fo swirljetm1 -Nh 2 -mo swirljetm1porb -param S -thetamax 1 -h0 0.5 -scount 4 -maxcount -1 -paramtarget 1.9
 ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi swirljetm2.hopf -fo swirljetm2 -Nh 2 -mo swirljetm2porb -param S -thetamax 1 -h0 -0.5 -scount 4 -maxcount -1 -paramtarget 1.8
 ```
 NOTE: in the actual paper, $N_h=4$ to $6$ was used to accurately resolve the periodic orbits. $N_h=2$ is used here to reduce computational cost.
 
-16. Compute periodic solutions at $S=1.9$ ($|m|=1$) and $S=1.8$ ($|m|=2$) with $N_h=3$ using a block preconditioner.
+17. Compute periodic solutions at $S=1.9$ ($|m|=1$) and $S=1.8$ ($|m|=2$) with $N_h=3$ using a block preconditioner.
 ```sh
 cd $workdir && export m1file=$(printf '%s\n' swirljetm1_*.porb | sort -t_ -k2,2n | tail -1) && cd -
 ff-mpirun -np $nproc porbcompute.md -v 0 -dir $workdir -fi $m1file -fo swirljetm1 -Nh 3 -S 1.9 -blocks 3
@@ -173,7 +179,7 @@ ff-mpirun -np $nproc porbcompute.md -v 0 -dir $workdir -fi $m2file -fo swirljetm
 ```
 
 ### Bifurcations to aperiodic 3D dynamics
-17. Compute Floquet stability of periodic solutions against each other 
+18. Compute Floquet stability of periodic solutions against each other 
 ```sh
 ff-mpirun -np $nproc floqcompute.md -v 0 -dir $workdir -fi swirljetm1.porb -fo swirljetm1 -Nh 3 -eps_target 0.1+0.3i -sym -2 -S 1.9 -blocks 3 -eps_pos_gen_non_hermitian
 ff-mpirun -np $nproc floqcompute.md -v 0 -dir $workdir -fi swirljetm2.porb -fo swirljetm2 -Nh 3 -eps_target 0.02-0.75i -sym -1 -S 1.8 -blocks 3 -eps_pos_gen_non_hermitian

--- a/fohocompute.md
+++ b/fohocompute.md
@@ -77,9 +77,11 @@ DmeshCreate(Th);
 restu = restrict(XMh, XMhg, n2o);
 XMh<complex> defu(ub), defu(um), defu(uma), defu(um2), defu(um3);
 if (fileext2 == "fold") {
-  real[string] alphaR;
-  real betaR;
   ub[].re = loadfold(fileroot2, meshin, um2[].re, um3[].re, alpha2, beta22);
+}
+else if(fileext2 == "cusp") {
+  real[string] alphaR;
+  ub[] = loadcusp(fileroot, meshin, um2[].re, um3[].re, alpha2, alphaR, beta23);
 }
 else if(fileext2 == "foho") {
   real omega;
@@ -148,6 +150,12 @@ else if(basefileext == "fold") {
   real beta;
   real[int] qm, qma;
   ub[].re = loadfold(basefileroot, meshin, qm, qma, alpha, beta);
+}
+else if(basefileext == "cusp") {
+  real[string] alpha, alphaR;
+  real beta;
+  real[int] qm, qma;
+  ub[].re = loadcusp(basefileroot, meshin, qm, qma, alpha, alphaR, beta);
 }
 else if(basefileext == "hopf") {
   real omega;
@@ -307,7 +315,7 @@ complex[int] R(ub[].n), q1m(J.n), q1ma(J.n), p1P(J.n), q1P(J.n), q2m(J.n), q2ma(
       omega = zerofreq ? 0.0 : paramvals(1);
       updateparam(param2, paramvals(2-zerofreq));
       sym = 0;
-      R = vR(0, XMh, tgv = -1);
+      R = vR(0, XMh, tgv = TGV);
       complex[int] Ra;
       ChangeNumbering(J, R, Ra); // FreeFEM to PETSc
       iomega = 1i*omega;
@@ -348,7 +356,7 @@ complex[int] R(ub[].n), q1m(J.n), q1ma(J.n), p1P(J.n), q1P(J.n), q2m(J.n), q2ma(
       updateparam(param, paramvals(0) + eps);
       omega = zerofreq ? 0.0 : paramvals(1);
       updateparam(param2, paramvals(2-zerofreq));
-      um2[] = vR(0, XMh, tgv = -1);
+      um2[] = vR(0, XMh, tgv = TGV);
       um2[] -= R;
       um2[] /= eps;
       complex[int] temp1(J.n), temp3(J.n);
@@ -364,7 +372,7 @@ complex[int] R(ub[].n), q1m(J.n), q1ma(J.n), p1P(J.n), q1P(J.n), q2m(J.n), q2ma(
       updateparam(param2, paramvals(2-zerofreq) + eps2);
       complex[int] Hl2 = vJ(0, XMh, tgv = -10);
       sym = 0;
-      um2[] = vR(0, XMh, tgv = -1);
+      um2[] = vR(0, XMh, tgv = TGV);
       um2[] -= R;
       um2[] /= eps2;
       ChangeNumbering(J, um2[], temp3); // FreeFEM to PETSc
@@ -418,7 +426,7 @@ complex[int] R(ub[].n), q1m(J.n), q1ma(J.n), p1P(J.n), q1P(J.n), q2m(J.n), q2ma(
       if (zerofreq) tempPms = [[temp1, temp3]];
       else tempPms = [[temp1, q2m, temp3]]; // dense array to sparse matrix
       ChangeOperator(gqPM, tempPms, parent = Ja); // send to Mat
-      J = vJ(XMh, XMh, tgv = -1);
+      J = vJ(XMh, XMh, tgv = TGV);
       return 0;
   }
 // set up Mat parameters
@@ -543,16 +551,16 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um2[], p2P);
     tempPms = [[p2P]]; // dense array to sparse matrix
     ChangeOperator(qPM, tempPms, parent = Ja); // send to Mat
-    J = vJ(XMh, XMh, tgv = -1);
+    J = vJ(XMh, XMh, tgv = TGV);
     if(paramnames[0] != ""){
       for (int k = 0; k < paramnames.n; ++k){
         real paramval = getparam(paramnames[k]);
         updateparam(paramnames[k], paramval + eps);
-        um[] = vR(0, XMh, tgv = -1);
+        um2[] = vR(0, XMh, tgv = TGV);
         updateparam(paramnames[k], paramval);
-        um[] -= R;
-        um[] /= -eps;
-        ChangeNumbering(J, um[], q1P); // FreeFEM to PETSc
+        um2[] -= R;
+        um2[] /= -eps;
+        ChangeNumbering(J, um2[], q1P); // FreeFEM to PETSc
         q1P.resize(Ja.n);
         if(mpirank == 0) q1P(Ja.n-1) = 0.0;
         KSPSolve(Ja, q1P, q1P);
@@ -562,7 +570,6 @@ if (ret > 0) { // Save solution if solver converged and output file is given
       }
     }
     //  B: base modifications due to quadratic nonlinear interactions
-    ChangeNumbering(J, um[], q2m, inverse = true, exchange = true);
     um2[] = -0.5*um[];
     um3[] = vH(0, XMh, tgv = -10);
     ChangeNumbering(J, um3[], p2P); // FreeFEM to PETSc
@@ -599,7 +606,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um3[], p1P); // FreeFEM to PETSc
     ik.im = sym;
     iomega = 2i*omega;
-    J = vJ(XMh, XMh, tgv = -1);
+    J = vJ(XMh, XMh, tgv = TGV);
     KSPSolve(J, p1P, p1P);
         
     ik.im = sym1;
@@ -617,7 +624,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um2[], q2P);
     tempPms = [[q2P]]; // dense array to sparse matrix
     ChangeOperator(qPM, tempPms, parent = Ja); // send to Mat
-    J = vJ(XMh, XMh, tgv = -1);
+    J = vJ(XMh, XMh, tgv = TGV);
     ChangeNumbering(J, um2[], q2m, inverse = true, exchange = true);
     um3[] = vH(0, XMh, tgv = -10);
     um3[] *= -1.0;
@@ -780,7 +787,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
       if(paramnames[0] != ""){
         for (int k = 0; k < paramnames.n; ++k){
           ChangeNumbering(J, vec[0][], qDa(k, :), inverse = true); // FreeFEM to PETSc
-          savemode(fileout + "_wnl_param" + k, "", fileout + ".hoho", meshout, vec, val, sym, true);
+          savemode(fileout + "_wnl_param" + k, "", fileout + ".foho", meshout, vec, val, sym, true);
         }
       }
       ChangeNumbering(J, vec[0][], p2P, inverse = true); // FreeFEM to PETSc

--- a/fohocompute.md
+++ b/fohocompute.md
@@ -31,7 +31,7 @@ ff-mpirun -np 4 fohocompute.md -param <PARAM1> -param2 <PARAM2> -fi1 <FILEIN1> -
 
 NOTE: This file should not be changed unless you know what you're doing.
 
-SEE ALSO: [modecompute.md](./modecompute.md), [foldcompute.md](./foldcompute.md), [foldcontinue.md](./foldcontinue.md), [hopfcompute.md](./hopfcompute.md), [hopfcontinue.md](./hopfcontinue.md), [fohocompute.md](./fohocompute.md), [porbcontinue.md](./porbcontinue.md)
+SEE ALSO: [modecompute.md](./modecompute.md), [foldcompute.md](./foldcompute.md), [foldcontinue.md](./foldcontinue.md), [cuspcompute.md](./cuspcompute.md), [hopfcompute.md](./hopfcompute.md), [hopfcontinue.md](./hopfcontinue.md), [porbcontinue.md](./porbcontinue.md)
 
 ```freefem
 load "iovtk"

--- a/foldcompute.md
+++ b/foldcompute.md
@@ -80,6 +80,11 @@ if(fileext == "base") {
 else if(fileext == "fold") {
   ub[] = loadfold(fileroot, meshin, um[], uma[], alpha, beta);
 }
+else if(fileext == "cusp") {
+  real[string] alphaR;
+  real betaR;
+  ub[] = loadcusp(fileroot, meshin, um[], uma[], alpha, alphaR, betaR);
+}
 else if(fileext == "foho") {
   real omega, beta23, gamma22, gamma23;
   complex[string] alpha1;

--- a/foldcompute.md
+++ b/foldcompute.md
@@ -37,7 +37,7 @@ ff-mpirun -np 4 foldcompute.md -param <PARAM> -fi <FILEIN> -fo <FILEOUT> -mo <ME
 
 NOTE: This file should not be changed unless you know what you're doing.
 
-SEE ALSO: [modecompute.md](./modecompute.md), [basecontinue.md](./basecontinue.md), [foldcontinue.md](./foldcontinue.md), [hopfcontinue.md](./hopfcontinue.md), [fohocompute.md](./fohocompute.md)
+SEE ALSO: [modecompute.md](./modecompute.md), [basecontinue.md](./basecontinue.md), [cuspcompute.md](./cuspcompute.md), [foldcontinue.md](./foldcontinue.md), [hopfcontinue.md](./hopfcontinue.md), [fohocompute.md](./fohocompute.md)
 
 ```freefem
 load "iovtk"

--- a/foldcontinue.md
+++ b/foldcontinue.md
@@ -62,7 +62,7 @@ if(count > 0) {
   fileroot = fileroot(0:fileroot.rfind("_" + count)-1); // get file root
   meshroot = meshroot(0:meshroot.rfind("_" + count)-1); // get file root
 }
-assert(fileext == "fold" || fileext == "foho");
+assert(fileext == "fold" || fileext == "cusp" || fileext == "foho");
 Th = readmeshN(workdir + meshin);
 Thg = Th;
 DmeshCreate(Th);
@@ -71,6 +71,11 @@ XMh defu(ub), defu(um), defu(uma), defu(um2), defu(um3);
 if (count == 0){
   if(fileext == "fold"){
     ub[] = loadfold(fileroot, meshin, um[], uma[], alpha, beta);
+  }
+  else if(fileext == "cusp") {
+    real[string] alphaR;
+    real betaR;
+    ub[] = loadcusp(fileroot, meshin, um[], uma[], alpha, alphaR, betaR);
   }
   else if(fileext == "foho") {
     real omega, gamma22, gamma23, beta23;

--- a/foldcontinue.md
+++ b/foldcontinue.md
@@ -13,7 +13,7 @@ ff-mpirun -np 4 foldcontinue.md -param <PARAM1> -param2 <PARAM2> -fi <FILEIN> -f
 
 NOTE: This file should not be changed unless you know what you're doing.
 
-SEE ALSO: [modecompute.md](./modecompute.md), [basecontinue.md](./basecontinue.md), [foldcompute.md](./foldcompute.md), [hopfcontinue.md](./hopfcontinue.md), [fohocompute.md](./fohocompute.md)
+SEE ALSO: [modecompute.md](./modecompute.md), [basecontinue.md](./basecontinue.md), [foldcompute.md](./foldcompute.md), [cuspcompute.md](./cuspcompute.md), [hopfcontinue.md](./hopfcontinue.md), [fohocompute.md](./fohocompute.md)
 
 ```freefem
 load "iovtk"

--- a/hohocompute.md
+++ b/hohocompute.md
@@ -645,17 +645,16 @@ if (ret > 0) { // Save solution if solver converged and output file is given
       for (int k = 0; k < paramnames.n; ++k){
         real paramval = getparam(paramnames[k]);
         updateparam(paramnames[k], paramval + eps);
-        um[] = vR(0, XMh, tgv = TGV);
+        um2[] = vR(0, XMh, tgv = TGV);
         updateparam(paramnames[k], paramval);
-        um[] -= R;
-        um[] /= -eps;
-        ChangeNumbering(J, um[], q1P); // FreeFEM to PETSc
+        um2[] -= R;
+        um2[] /= -eps;
+        ChangeNumbering(J, um2[], q1P); // FreeFEM to PETSc
         KSPSolve(J, q1P, q1P);
         qDa(k, :) = q1P;
       }
     }
     //  B: base modifications due to quadratic nonlinear interactions
-    ChangeNumbering(J, um[], q2m, inverse = true, exchange = true);
     um2[] = conj(um[]);
     ik.im = sym2;
     ik2.im = -sym2;

--- a/hohocompute.md
+++ b/hohocompute.md
@@ -191,6 +191,12 @@ else if(basefileext == "fold") {
   real[int] qm, qma;
   ub[].re = loadfold(basefileroot, meshin, qm, qma, alpha, beta);
 }
+else if(basefileext == "cusp") {
+  real[string] alpha, alphaR;
+  real beta;
+  real[int] qm, qma;
+  ub[].re = loadcusp(basefileroot, meshin, qm, qma, alpha, alphaR, beta);
+}
 else if(basefileext == "hopf") {
   real omega;
   complex[string] alpha;

--- a/hopfcompute.md
+++ b/hopfcompute.md
@@ -308,6 +308,12 @@ else if(basefileext == "fold") {
   real[int] qm, qma;
   ub[].re = loadfold(basefileroot, meshin, qm, qma, alpha, beta);
 }
+else if(basefileext == "cusp") {
+  real[string] alpha, alphaR;
+  real beta;
+  real[int] qm, qma;
+  ub[].re = loadcusp(basefileroot, meshin, qm, qma, alpha, alphaR, beta);
+}
 else if(basefileext == "hopf") {
   real omega;
   complex[string] alpha;

--- a/macros_bifbox.idp
+++ b/macros_bifbox.idp
@@ -2248,6 +2248,123 @@ macro savefoho(fohofileout, statsfile, meshfile, sym, omega, alpha1, alpha2, bet
   }
 }//EOM
 
+macro savecusp(cuspfileout, statsfile, meshfile, alpha1, alpha2, beta, saveflag, monitorflag){
+  IFMACRO(getmonitors)
+    XMhg defu(tempu), defu(ubg), defu(umg), defu(umag);
+    tempu[](restu) = ub[];
+    mpiAllReduce(tempu[], ubg[], mpiCommWorld, mpiSUM);
+    tempu[](restu) = um[];
+    mpiAllReduce(tempu[], umg[], mpiCommWorld, mpiSUM);
+    tempu[](restu) = uma[];
+    mpiAllReduce(tempu[], umag[], mpiCommWorld, mpiSUM);
+    if(monitorflag) getmonitors;
+  ENDIFMACRO
+  if(mpirank == 0 && monitorflag){
+    cout << "\t";
+    if(paramnames[0] != ""){
+      for (int k = 0; k < paramnames.n; ++k){
+        cout << "alpha[" + paramnames[k] + "] = [" + alpha1[paramnames[k]] + ", " + alpha2[paramnames[k]] + "], ";
+      }
+    }
+    cout << "beta = " + beta;
+    if(paramnames[0] != "") cout << ", " << listparams(paramnames, params);
+    if(monitornames[0] != "") cout << ", " << listparams(monitornames, monitors);
+    cout << "." << endl;
+  }
+  if (mpirank == 0 && statsfile != "") {
+    cout << "  Saving solution stats to '" + statsfile + ".cusp.stat' in '" + workdir + "'." << endl;
+    string dummy = cuspfileout;
+    {
+      ofstream file(workdir + statsfile + ".cusp.stat", append);
+      file.precision(17);
+      file << cuspfileout + ((dummy.rfind(".") > 0) ? "" : ".cusp") << "\t" << meshfile;
+      if(paramnames[0] != ""){
+        for (int k = 0; k < paramnames.n; ++k){
+          file << "\t" << alpha1[paramnames[k]] << "\t" << alpha2[paramnames[k]];
+        }
+      }
+      file << "\t" << beta;
+      if(paramnames[0] != ""){
+        for (int k = 0; k < paramnames.n; ++k){
+          file << "\t" << params[paramnames[k]];
+        }
+      }
+      if(monitornames[0] != ""){
+        for (int k = 0; k < monitornames.n; ++k){
+          file << "\t" << monitors[monitornames[k]];
+        }
+      }
+      file << endl;
+    }
+  }
+  if (saveflag && cuspfileout != ""){
+    IFMACRO(!getmonitors)
+      XMhg defu(tempu), defu(ubg), defu(umg), defu(umag);
+      tempu[](restu) = ub[];
+      mpiAllReduce(tempu[], ubg[], mpiCommWorld, mpiSUM);
+      tempu[](restu) = um[];
+      mpiAllReduce(tempu[], umg[], mpiCommWorld, mpiSUM);
+      tempu[](restu) = uma[];
+      mpiAllReduce(tempu[], umag[], mpiCommWorld, mpiSUM);
+    ENDIFMACRO
+    if(mpirank == 0){
+      cout << "  Saving '" + cuspfileout + ".cusp' on '" + meshfile + "' in '" + workdir + "'." << endl;
+      {
+        ofstream file(workdir + cuspfileout + ".cusp", binary);
+        file.precision(17);
+        file << "mesh\t" << meshfile << endl;
+        if(paramnames[0] != ""){
+          for (int k = 0; k < paramnames.n; ++k){
+            file << "alpha[" + paramnames[k] + "]\t" << alpha1[paramnames[k]] << "\t" << alpha2[paramnames[k]] << endl;
+          }
+        }
+        file << "beta\t" << beta << endl;
+        if(paramnames[0] != ""){
+          for (int k = 0; k < paramnames.n; ++k){
+            file << paramnames[k] << "\t" << params[paramnames[k]] << endl;
+          }
+        }
+        if(monitornames[0] != ""){
+          for (int k = 0; k < monitornames.n; ++k){
+            file << monitornames[k] << "\t" << monitors[monitornames[k]] << endl;
+          }
+        }
+        file << ubg[] << endl;
+        file << umg[] << endl;
+        file << umag[] << endl;
+      }
+      if (paraviewflag > 0){
+        cout << "  Saving '" + cuspfileout + "_cusp_[base,dirmode,adjmode].vtu' in '" + workdir + "'." << endl;
+        meshN Thgpv;
+        real[int] qpv = ubg[], qmpv = umg[], qmapv = umag[];
+        if (paraviewflag > 1){
+          meshN Thgs = trunc(Thg, 1, split = paraviewflag);
+          fespace XMhs(Thgs, Pk);
+          XMhs defu(us) = defu(umg);
+          qpv.resize(us[].n);
+          qmpv.resize(us[].n);
+          qmapv.resize(us[].n);
+          qmpv = us[];
+          defu(us) = defu(umag);
+          qmapv = us[];
+          defu(us) = defu(ubg);
+          qpv = us[];
+          Thgpv = movemesh(Thgs, [coordinatetransform(us)]);
+        }
+        else Thgpv = movemesh(Thg, [coordinatetransform(ubg)]);
+        fespace XMhgpv(Thgpv, Pk);
+        XMhgpv defu(ugr);
+        ugr[] = qpv;
+        savevtk(workdir + cuspfileout + "_cusp_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
+        ugr[] = qmpv;
+        savevtk(workdir + cuspfileout + "_cusp_dirmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
+        ugr[] = qmapv;
+        savevtk(workdir + cuspfileout + "_cusp_adjmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
+      }
+    }
+  }
+}//EOM
+
 macro saveporb(porbfileout, statsfile, meshfile, sym, omega, Nh, saveflag, monitorflag){
   IFMACRO(getmonitors)
     XMhg defu(tempu), defu(ubg);
@@ -3015,6 +3132,64 @@ func real[int] loadfoho(string inputfilename, string meshfilename, complex[int] 
       q1malocal = u1mag[](restu);
       q2mlocal = u2mg[](restu);
       q2malocal = u2mag[](restu);
+      return qlocal;
+    }
+
+func real[int] loadcusp(string inputfilename, string meshfilename, real[int] & qmlocal, real[int] & qmalocal, real[string] & alpha1, real[string] & alpha2, real & beta) {
+      XMhg defu(ubg), defu(umg), defu(umag);
+      if (mpirank == 0) cout << "  Loading '" + inputfilename + ".cusp' on '" + meshfilename + "' from '" + workdir + "'." << endl;
+      string dummy, filemesh;
+      ifstream file(workdir + inputfilename + ".cusp");
+      file >> filemesh >> filemesh;
+      if(paramnames[0] != ""){
+        for (int k = 0; k < paramnames.n; ++k){
+          file >> dummy >> alpha1[paramnames[k]] >> alpha2[paramnames[k]];
+        }
+      }
+      file >> dummy >> beta;
+      if(paramnames[0] != ""){
+        for (int k = 0; k < paramnames.n; ++k){
+          file >> paramnames[k] >> params[paramnames[k]];
+        }
+      }
+      if(monitornames[0] != ""){
+        for (int k = 0; k < monitornames.n; ++k){
+          file >> monitornames[k] >> monitors[monitornames[k]];
+        }
+      }
+      if (mpirank == 0) {
+        cout << "\t";
+        if(paramnames[0] != ""){
+          for (int k = 0; k < paramnames.n; ++k){
+            cout << "alpha[" + paramnames[k] + "] = [" + alpha1[paramnames[k]] + ", " + alpha2[paramnames[k]] + "], ";
+          }
+        }
+        cout << "beta = " + (beta);
+        if(paramnames[0] != "") cout << ", " + listparams(paramnames, params);
+        if(monitornames[0] != "") cout << ", " + listparams(monitornames, monitors);
+        cout << "." << endl;
+      }
+      if (filemesh == meshfilename){ // no interpolation needed
+        file >> ubg[];
+        file >> umg[];
+        file >> umag[];
+      }
+      else { // must interpolate
+        if (mpirank == 0) cout << "\tMesh mismatch. Interpolating from '" << filemesh << "'." << endl;
+        meshN Thg1 = readmeshN(workdir + filemesh);
+        fespace XMhg1(Thg1, Pk);
+        XMhg1 defu(ubg1), defu(umg1), defu(umag1);
+        file >> ubg1[];
+        file >> umg1[];
+        file >> umag1[];
+        defu(ubg) = defu(ubg1);
+        defu(umg) = defu(umg1);
+        defu(umag) = defu(umag1);
+      }
+      setparams(paramnames, params);
+      real[int] qlocal = ubg[](restu);
+      qmlocal = umg[](restu);
+      qmalocal = umag[](restu);
       return qlocal;
     }
 

--- a/meshcompute.md
+++ b/meshcompute.md
@@ -57,7 +57,7 @@ for (ii = 0; ii < filecount; ii++) {
   if(meshin == "") meshin = readmeshname(workdir + fileins[ii]); // get mesh file
   if( fileexts[ii] == "base" || fileexts[ii] == "tdns" ) nuvec++;
   else if ( fileexts[ii] == "mode" || fileexts[ii] == "tdls" || fileexts[ii] == "resp" ) nuvec += 2;
-  else if ( fileexts[ii] == "fold" ) nuvec += 3;
+  else if ( fileexts[ii] == "fold" || fileexts[ii] == "cusp" ) nuvec += 3;
   else if ( fileexts[ii] == "hopf" || fileexts[ii] == "porb" ) nuvec += 5;
   else if ( fileexts[ii] == "foho" ) nuvec += 7;
   else if ( fileexts[ii] == "hoho" ) nuvec += 9;

--- a/meshcompute.md
+++ b/meshcompute.md
@@ -114,6 +114,14 @@ if (mpirank==0){ // Perform mesh adaptation (serially) on processor 0
       if(adaptto == "bd" || adaptto == "bda") uvecs(jj++, :) = qm;
       if(adaptto == "ba" || adaptto == "bda") uvecs(jj++, :) = qma;
     }
+    else if(fileexts[ii] == "cusp") {
+      real[string] alpha, alphaR;
+      real beta;
+      real[int] qm(XMhg.ndof), qma(XMhg.ndof);
+      uvecs(jj++, :) = loadcusp(fileroots[ii], meshin, qm, qma, alpha, alphaR, beta);
+      if(adaptto == "bd" || adaptto == "bda") uvecs(jj++, :) = qm;
+      if(adaptto == "ba" || adaptto == "bda") uvecs(jj++, :) = qma;
+    }
     else if(fileexts[ii] == "hopf") {
       real omega;
       complex[string] alpha;

--- a/modecompute.md
+++ b/modecompute.md
@@ -68,6 +68,12 @@ else if(fileext == "fold") {
   real[int] qm, qma;
   ub[] = loadfold(fileroot, meshin, qm, qma, alpha, beta);
 }
+else if(fileext == "cusp") {
+  real[string] alpha, alphaR;
+  real beta;
+  real[int] qm, qma;
+  ub[] = loadcusp(fileroot, meshin, qm, qma, alpha, alphaR, beta);
+}
 else if(fileext == "hopf") {
   real omega;
   complex[string] alpha;

--- a/porbcompute.md
+++ b/porbcompute.md
@@ -122,6 +122,12 @@ else if(basefileext == "fold") {
   real[int] qm, qma;
   ub[] = loadfold(basefileroot, meshin, qm, qma, alpha, beta);
 }
+else if(basefileext == "cusp") {
+  real[string] alpha, alphaR;
+  real beta;
+  real[int] qm, qma;
+  ub[] = loadcusp(basefileroot, meshin, qm, qma, alpha, alphaR, beta);
+}
 else if(basefileext == "hopf") {
   real omega;
   complex[string] alpha;

--- a/printparaview.md
+++ b/printparaview.md
@@ -153,6 +153,37 @@ if (mpirank==0){
     ugr[] = qmapv;
     savevtk(workdir + fileout + "_fold_adjmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
   }
+  else if (fileext == "cusp"){
+    XMhg defu(ubg), defu(umg), defu(umag);
+    real[string] alpha1, alpha2;
+    real beta;
+    ubg[] = loadcusp(fileroot, meshin, umg[], umag[], alpha1, alpha2, beta);
+    cout << "  Saving '" + fileout + "_cusp_[base,dirmode,adjmode].vtu' in '" + workdir + "'." << endl;
+    real[int] qpv = ubg[], qmpv = umg[], qmapv = umag[];
+    if (paraviewflag > 1){
+      meshN Thgs = trunc(Thg, 1, split = paraviewflag);
+      fespace XMhs(Thgs, Pk);
+      XMhs defu(us) = defu(umg);
+      qpv.resize(us[].n);
+      qmpv.resize(us[].n);
+      qmapv.resize(us[].n);
+      qmpv = us[];
+      defu(us) = defu(umag);
+      qmapv = us[];
+      defu(us) = defu(ubg);
+      qpv = us[];
+      Thgpv = movemesh(Thgs, [coordinatetransform(us)]);
+    }
+    else Thgpv = movemesh(Thg, [coordinatetransform(ubg)]);
+    fespace XMhgpv(Thgpv, Pk);
+    XMhgpv defu(ugr);
+    ugr[] = qpv;
+    savevtk(workdir + fileout + "_cusp_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
+    ugr[] = qmpv;
+    savevtk(workdir + fileout + "_cusp_dirmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
+    ugr[] = qmapv;
+    savevtk(workdir + fileout + "_cusp_adjmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
+  }
   else if (fileext == "hopf"){
     XMhg defu(ubg);
     XMhg<complex> defu(umg), defu(umag);

--- a/respcompute.md
+++ b/respcompute.md
@@ -54,6 +54,12 @@ else if(fileext == "fold") {
   real[int] qm, qma;
   ub[] = loadfold(fileroot, meshin, qm, qma, alpha, beta);
 }
+else if(fileext == "cusp") {
+  real[string] alpha, alphaR;
+  real beta;
+  real[int] qm, qma;
+  ub[] = loadcusp(fileroot, meshin, qm, qma, alpha, alphaR, beta);
+}
 else if(fileext == "hopf") {
   real omega;
   complex[string] alpha;

--- a/rslvcompute.md
+++ b/rslvcompute.md
@@ -58,6 +58,12 @@ else if(fileext == "fold") {
   real[int] qm, qma;
   ub[] = loadfold(fileroot, meshin, qm, qma, alpha, beta);
 }
+else if(fileext == "cusp") {
+  real[string] alpha, alphaR;
+  real beta;
+  real[int] qm, qma;
+  ub[] = loadcusp(fileroot, meshin, qm, qma, alpha, alphaR, beta);
+}
 else if(fileext == "hopf") {
   real omega;
   complex[string] alpha;

--- a/tdlscompute.md
+++ b/tdlscompute.md
@@ -141,6 +141,12 @@ else if(basefileext == "fold") {
   real[int] qm, qma;
   ub[] = loadfold(basefileroot, meshin, qm, qma, alpha, beta);
 }
+else if(basefileext == "cusp") {
+  real[string] alpha, alphaR;
+  real beta;
+  real[int] qm, qma;
+  ub[] = loadcusp(basefileroot, meshin, qm, qma, alpha, alphaR, beta);
+}
 else if(basefileext == "hopf") {
   real omega;
   real[int] sym1(sym.n);

--- a/tdnscompute.md
+++ b/tdnscompute.md
@@ -102,6 +102,14 @@ if (count == 0){
     if(adj) qm = qma;
     um[] = qm;
   }
+  else if(fileext == "cusp") {
+    real[string] alpha, alphaR;
+    real beta;
+    real[int] qm(um[].n), qma(um[].n);
+    ub[] = loadfold(fileroot, meshin, qm, qma, alpha, alphaR, beta);
+    if(adj) qm = qma;
+    um[] = qm;
+  }
   else if(fileext == "hopf") {
     real omega;
     complex[string] alpha;
@@ -182,6 +190,12 @@ if (count == 0){
     real beta;
     real[int] qm, qma;
     ub[] = loadfold(basefileroot, meshin, qm, qma, alpha, beta);
+  }
+  else if(basefileext == "cusp") {
+    real[string] alpha, alphaR;
+    real beta;
+    real[int] qm, qma;
+    ub[] = loadcusp(basefileroot, meshin, qm, qma, alpha, alphaR, beta);
   }
   else if(basefileext == "hopf") {
     real omega;


### PR DESCRIPTION
Implements a miminally-augmented Newton scheme to compute cusp bifurcations and their normal forms.

Also introduces `.cusp` filetypes with file I/O across other solvers.