### PR TITLE
Allow `maxcount` with `paramtarget`

### DIFF
--- a/basecontinue.md
+++ b/basecontinue.md
@@ -44,9 +44,9 @@ bool stricttangent = bool(getARGV("-stricttangent", 1));
 int snesmaxit = getARGV("-snes_max_it", 10);
 string sneslinesearchtype = getARGV("-snes_linesearch_type", "none");
 int refactor = getARGV("-refact", snesmaxit);
-real paramtarget = getARGV("-paramtarget", 1.0);
+real paramtarget = getARGV("-paramtarget", -1.0e30);
 real TGV = getARGV("-tgv", -1);
-bool stopflag = false;
+bool stopflag = (maxcount == 0);
 bool forcesave = false;
 
 // Load mesh, make FE basis
@@ -299,9 +299,7 @@ while (!stopflag){
   SNESSolve(Ja, funcJa, funcRa, qa, convergence = funcConvergence, reason = ret,
             sparams = "-snes_linesearch_type " + sneslinesearchtype + " -snes_converged_reason -options_left no -snes_max_it " + snesmaxit); // solve nonlinear problem with SNES
   if (ret > 0) {
-    ++count;
-    if (maxcount > 0) stopflag = (count >= maxcount);
-    else if ((paramval - paramtarget)*paramdiff <= 0) stopflag = true;
+    stopflag = (maxcount > 0)*(++count >= maxcount) || ((paramval - paramtarget)*paramdiff <= 0);
     h0 /= f;
     if (cosalpha < 0 && contorder > 0) {
       h0 *= -1.0;

--- a/examples/.ci-suite/2d-brusselator.sh
+++ b/examples/.ci-suite/2d-brusselator.sh
@@ -18,7 +18,7 @@ ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi oe_2.mode -fo brussel
 ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi brusselator10.hopf -fo brusselator10 -param B -param2 A -snes_rtol 0 -maxcount 3
 # CONTINUE PERIODIC SOLUTION BRANCHES FROM HOPF POINTS
 ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi brusselator30.hopf -fo brusselator30 -param 1/L^2 -maxcount 2 -h0 -1 -Nh 6
-ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi brusselator30_2.porb -fo brusselator30 -param 1/L^2 -paramtarget 0.25 -maxcount -1 -h0 -0.03 -dmax 1e10 -mono 0 -contorder 0 -count 2
+ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi brusselator30_2.porb -fo brusselator30 -param 1/L^2 -paramtarget 0.25 -h0 -0.03 -dmax 1e10 -mono 0 -contorder 0 -count 2
 # DEFLATION OF PERIODIC SOLUTION BRANCH
 ff-mpirun -np $nproc porbcompute.md -v 0 -dir $workdir -fi brusselator30_7.porb -fo brusselator_branch-0 -1/L^2 0.25
 ff-mpirun -np $nproc porbdeflate.md -v 0 -dir $workdir -fi brusselator_branch-0.porb -fi2 brusselator_branch-0.porb -fo brusselator_branch -ndeflate 2 -snes_rtol 0 -noise 0.03 -snes_linesearch_type l2 -snes_linesearch_damping 0.8

--- a/examples/.ci-suite/2d-buckling.sh
+++ b/examples/.ci-suite/2d-buckling.sh
@@ -8,14 +8,14 @@ ln -sf examples/.ci-suite/2d-buckling_settings.idp settings.idp
 # build meshes
 FreeFem++-mpi -v 0 examples/.ci-suite/2d-buckling_mesh.md -mo $workdir/beam
 # continue and compute base state
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -mi beam.msh -fo buckling -param P -nu 0.3 -snes_rtol 0 -h0 0.1 -amax 15 -tgv -2 -paramtarget 0.1 -maxcount -1 -dmax 0.1 -kmax 0.25
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -mi beam.msh -fo buckling -param P -nu 0.3 -snes_rtol 0 -h0 0.1 -amax 15 -tgv -2 -paramtarget 0.1 -dmax 0.1 -kmax 0.25
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi buckling_1.base -fo buckling_A -P 0.05 -tgv -2
 # compute and continue fold points
 cd "$workdir" && declare -a foldguesslist=(buckling_*specialpt.base) && cd -
 for guess in "${foldguesslist[@]}"; do
 export out=$(echo "$guess" | awk -F'specialpt' '{print $1}')
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi $guess -fo $out -param P -tgv -2 -snes_atol 1e-10
-ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi "$out".fold -fo $out -param P -param2 nu -tgv -2 -h0 0.1 -snes_atol 1e-10 -maxcount -1 -param2target 0.49
+ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi "$out".fold -fo $out -param P -param2 nu -tgv -2 -h0 0.1 -snes_atol 1e-10 -param2target 0.49
 done
 # stability analysis
 ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi "$out".fold -so buckling -eps_target 0.1+0i -eps_nev 3 -eps_gen_hermitian -sym 0
@@ -23,9 +23,9 @@ ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi "$out".fold -so buckl
 ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi buckling_A.base -fo buckling_A -eps_target 0.1+0i -eps_nev 3 -eps_gen_hermitian -sym 1
 # pitchfork bifurcations
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi buckling_A.mode -fo buckling_A -param P -tgv -2 -snes_atol 1e-10 -zero 1
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi buckling_A.hopf -fo buckling_A.hopf -param P -param2 nu -tgv -2 -snes_atol 1e-10 -maxcount -1 -param2target 0.49 -zero 1
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi buckling_A.hopf -fo buckling_A.hopf -param P -param2 nu -tgv -2 -snes_atol 1e-10 -param2target 0.49 -zero 1
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi buckling_B.mode -fo buckling_B -param P -tgv -2 -snes_atol 1e-10 -zero 1
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi buckling_B.hopf -fo buckling_B.hopf -param P -param2 nu -tgv -2 -snes_atol 1e-10 -maxcount -1 -param2target 0.49 -zero 1
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi buckling_B.hopf -fo buckling_B.hopf -param P -param2 nu -tgv -2 -snes_atol 1e-10 -param2target 0.49 -zero 1
 # deflation
 ff-mpirun -np $nproc basedeflate.md -v 0 -dir $workdir -fi buckling_A.base -fo buckling_branch -ndeflate 3 -tgv -2 -snes_linesearch_linesearch l2 -snes_rtol 0 -defp 1 -P 0.04 -snes_divergence_tolerance 1e15 -snes_max_it 1000
 # test printparaview.md for failures

--- a/examples/.ci-suite/2d-cylinder.sh
+++ b/examples/.ci-suite/2d-cylinder.sh
@@ -9,7 +9,7 @@ ln -sf examples/.ci-suite/2d-cylinder_settings.idp settings.idp
 FreeFem++-mpi -v 0 examples/.ci-suite/2d-cylinder_mesh.md -mo $workdir/cylinder_0
 # compute and continue base state
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -mi cylinder_0.msh -1/Re 1 -fo cylinder_0
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi cylinder_0.base -fo cylinder -h0 -1 -param 1/Re -paramtarget 0.021 -maxcount -1 -mo cylinder -scount 1 -thetamax 1
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi cylinder_0.base -fo cylinder -h0 -1 -param 1/Re -paramtarget 0.021 -maxcount 10 -mo cylinder -scount 1 -thetamax 1
 cd $workdir && export lastfile=$(printf '%s\n' cylinder_*.base | sort -t_ -k2,2n | tail -1) && cd -
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi $lastfile -1/Re 0.021 -fo cylinder50
 # stability analysis
@@ -18,7 +18,7 @@ ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi cylinder50.base -fo c
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylinder50.mode -fo cylinder -param 1/Re -nf 0
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylinder.hopf -fo cylinderadapt -mo cylinderhopf -adaptto bo -param 1/Re -thetamax 5 -wnl 1 -thetamax 1
 # trace periodic orbit
-ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi cylinder.hopf -fo cylinderNh1 -Nh 1 -param 1/Re -h0 -1 -scount 1 -maxcount -1 -paramtarget 0.02
+ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi cylinder.hopf -fo cylinderNh1 -Nh 1 -param 1/Re -h0 -1 -scount 1 -maxcount 20 -paramtarget 0.02
 cd $workdir && export lastfile=$(printf '%s\n' cylinderNh1_*.porb | sort -t_ -k2,2n | tail -1) && cd -
 ff-mpirun -np $nproc porbcompute.md -v 0 -dir $workdir -fi $lastfile -mo cylinder50porb -fo cylinder50Nh2 -Nh 2 -1/Re 0.02 -blocks 2
 # test meshcompute.md and rslvcompute.md for failures

--- a/examples/chakravarthy_etal_2018/README.md
+++ b/examples/chakravarthy_etal_2018/README.md
@@ -75,7 +75,7 @@ FreeFem++-mpi -v 0 examples/chakravarthy_etal_2018/chakravarthy.md -mo $workdir/
 1. Compute jet state at $Pr=0.7$, $S=7$, $Re=200$, and $Ri=10^{-4}$.
 ```sh
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -mi jet_0.msh -fo jet_0 -Re 1 -Pr 0.7 -Ri 1.0e-4 -S 7
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi jet_0.base -fo jet -paramtarget 190 -param Re -scount 2 -mo jet -maxcount -1 -anisomax 1e6
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi jet_0.base -fo jet -paramtarget 190 -param Re -scount 2 -mo jet -anisomax 1e6
 cd $workdir && export lastfile=$(printf '%s\n' jet_*.base | sort -t_ -k2,2n | tail -1) && cd -
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi $lastfile -fo jet -Re 200 -mo jet -pv 1
 ```
@@ -93,5 +93,5 @@ ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi jet.base -fo jethopf 
 ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi jethopf.base -fo jethopf -eps_target 0.1+0.6i -eps_nev 1 -strict 1
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi jethopf.mode -fo jet -param S -snes_divergence_tolerance 1e30 -snes_linesearch_type l2 -nf 0
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi jet.hopf -fo jet -adaptto bda -mo jethopf -param S -pv 1 -anisomax 4
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi jet.hopf -fo jetplume -paramtarget 1.05 -param S -param2 Ri -scount 4 -mo jetplumehopf -adaptto bda -maxcount -1 -dmax 10 -anisomax 4
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi jet.hopf -fo jetplume -paramtarget 1.05 -param S -param2 Ri -scount 4 -mo jetplumehopf -adaptto bda -dmax 10 -anisomax 4
 ```

--- a/examples/douglas_etal_2021/README.md
+++ b/examples/douglas_etal_2021/README.md
@@ -82,7 +82,7 @@ ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -mi swirljet.msh -fo swir
 
 2. Continue base state along the parameter $1/Re$ with adaptive remeshing
 ```sh
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi swirljet.base -fo swirljet -param 1/Re -h0 -50 -scount 2 -maxcount -1 -paramtarget 0.01 -mo swirljet -thetamax 1
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi swirljet.base -fo swirljet -param 1/Re -h0 -50 -scount 2 -maxcount 10 -paramtarget 0.01 -mo swirljet -thetamax 1
 ```
 
 3. Compute base state at $Re=100$ with guess from $1/Re$ continuation
@@ -93,7 +93,7 @@ ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi $lastfile -fo swirlje
 
 4. Continue base state at $Re=100$ along the parameter $S$ with adaptive remeshing
 ```sh
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi swirljet100.base -fo swirljet100 -param S -h0 5 -scount 5 -maxcount -1 -mo swirljet100 -thetamax 1 -paramtarget 3
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi swirljet100.base -fo swirljet100 -param S -h0 5 -scount 5 -mo swirljet100 -thetamax 1 -paramtarget 3
 ```
 
 5. Compute backward and forward fold bifurcations from steady solution branch on base-adapted mesh
@@ -165,8 +165,8 @@ ff-mpirun -np $nproc fohocompute.md -v 0 -dir $workdir -fi $fohoguess -fo swirlj
 ### Periodic 3D dynamics
 16. Continue periodic solutions along $S$ from their initial Hopf points using the harmonic balance method with $N_h=2$.
 ```sh
-ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi swirljetm1.hopf -fo swirljetm1 -Nh 2 -mo swirljetm1porb -param S -thetamax 1 -h0 0.5 -scount 4 -maxcount -1 -paramtarget 1.9
-ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi swirljetm2.hopf -fo swirljetm2 -Nh 2 -mo swirljetm2porb -param S -thetamax 1 -h0 -0.5 -scount 4 -maxcount -1 -paramtarget 1.8
+ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi swirljetm1.hopf -fo swirljetm1 -Nh 2 -mo swirljetm1porb -param S -thetamax 1 -h0 0.5 -scount 4 -paramtarget 1.9
+ff-mpirun -np $nproc porbcontinue.md -v 0 -dir $workdir -fi swirljetm2.hopf -fo swirljetm2 -Nh 2 -mo swirljetm2porb -param S -thetamax 1 -h0 -0.5 -scount 4 -paramtarget 1.8
 ```
 NOTE: in the actual paper, $N_h=4$ to $6$ was used to accurately resolve the periodic orbits. $N_h=2$ is used here to reduce computational cost.
 

--- a/examples/douglas_etal_2022/README.md
+++ b/examples/douglas_etal_2022/README.md
@@ -94,7 +94,7 @@ ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi annularjet_6.base -fo
 
 4. Continue base state at $Re=100$ along the parameter $S$ with adaptive remeshing
 ```sh
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi annularjet100.base -fo annularjet100 -param S -h0 20 -scount 5 -maxcount -1 -mo annularjet100 -thetamax 1 -paramtarget 3
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi annularjet100.base -fo annularjet100 -param S -h0 20 -scount 5 -maxcount 120 -mo annularjet100 -thetamax 1 -paramtarget 3
 ```
 
 5. Compute backward and forward fold bifurcations from steady solution branch on base-adapted mesh

--- a/examples/douglas_lesshafft_2022/README.md
+++ b/examples/douglas_lesshafft_2022/README.md
@@ -122,25 +122,25 @@ ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi Re100_S0_L0_C40.base 
 ## Computations for Figure 2 (radially unconfined case)
 1. Continue base states along the parameter $S$ with adaptive remeshing
 ```sh
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0_unconfined.base -fo Re100_L0_unconfined -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L0_unconfined -paramtarget 3 -thetamax 1 -hmin 1e-5
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0p2_unconfined.base -fo Re100_L0p2_unconfined -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L0p2_unconfined -paramtarget 3 -thetamax 1 -hmin 1e-5
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L1_unconfined.base -fo Re100_L1_unconfined -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L1_unconfined -paramtarget 3 -thetamax 1 -hmin 1e-5
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L2_unconfined.base -fo Re100_L2_unconfined -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L2_unconfined -paramtarget 3 -thetamax 1 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0_unconfined.base -fo Re100_L0_unconfined -param S -h0 10 -scount 5 -mo Re100_L0_unconfined -paramtarget 3 -thetamax 1 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0p2_unconfined.base -fo Re100_L0p2_unconfined -param S -h0 10 -scount 5 -mo Re100_L0p2_unconfined -paramtarget 3 -thetamax 1 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L1_unconfined.base -fo Re100_L1_unconfined -param S -h0 10 -scount 5 -mo Re100_L1_unconfined -paramtarget 3 -thetamax 1 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L2_unconfined.base -fo Re100_L2_unconfined -param S -h0 10 -scount 5 -mo Re100_L2_unconfined -paramtarget 3 -thetamax 1 -hmin 1e-5
 ```
 2. Continue alternate branches of $L=0.2$ and $L=1$ solutions
 ```sh
 cd $workdir && export lastfile=$(printf '%s\n' Re100_L1_unconfined_*.base | sort -t_ -k4,4n | tail -1) && cd -
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi $lastfile -fo Re100_S3_L0p2_unconfined -L 0.2 -S 3
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi Re100_S3_L0p2_unconfined.base -fo Re100_S3_L0p2_unconfined -thetamax 1 -hmin 1e-5 -mo Re100_S3_L0p2_unconfined
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S3_L0p2_unconfined.base -fo Re100_L0p2_unconfined_b2 -param S -h0 -10 -scount 5 -maxcount -1 -mo Re100_L0p2_unconfined_b2 -paramtarget 3.01 -thetamax 1 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S3_L0p2_unconfined.base -fo Re100_L0p2_unconfined_b2 -param S -h0 -10 -scount 5 -mo Re100_L0p2_unconfined_b2 -paramtarget 3.01 -thetamax 1 -hmin 1e-5
 
 cd $workdir && export lastfile=$(printf '%s\n' Re100_L0p2_unconfined_*.base | sort -t_ -k4,4n | tail -n 3 | head -n 1) && cd -
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi $lastfile -fo Re100_S2p5_L1_unconfined -L 0.3 -S 2.5 -snes_linesearch_type secant
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi Re100_S2p5_L1_unconfined.base -fo Re100_S2p5_L1_unconfined -L 0.5 -snes_linesearch_type secant
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi Re100_S2p5_L1_unconfined.base -fo Re100_S2p5_L1_unconfined -L 1 -snes_linesearch_type secant
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi Re100_S2p5_L1_unconfined.base -fo Re100_S2p5_L1_unconfined -thetamax 1 -hmin 1e-5 -mo Re100_S2p5_L1_unconfined
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S2p5_L1_unconfined.base -fo Re100_L1_unconfined_b2 -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L1_unconfined_b2 -paramtarget 2.49 -thetamax 1 -hmin 1e-5 -snes_max_it 20
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S2p5_L1_unconfined.base -fo Re100_L1_unconfined_b3 -param S -h0 -10 -scount 5 -maxcount -1 -mo Re100_L1_unconfined_b3 -paramtarget 2.51 -thetamax 1 -hmin 1e-5 -snes_max_it 20
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S2p5_L1_unconfined.base -fo Re100_L1_unconfined_b2 -param S -h0 10 -scount 5 -mo Re100_L1_unconfined_b2 -paramtarget 2.49 -thetamax 1 -hmin 1e-5 -snes_max_it 20
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S2p5_L1_unconfined.base -fo Re100_L1_unconfined_b3 -param S -h0 -10 -scount 5 -mo Re100_L1_unconfined_b3 -paramtarget 2.51 -thetamax 1 -hmin 1e-5 -snes_max_it 20
 ```
 
 3. Compute backward and forward fold bifurcations from $L=0$ and $L=0.2$ solution branches
@@ -160,19 +160,19 @@ ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi Re100_L0p2_unconfined
 
 4. Continue the neutral fold curve in the $(S, L)$-plane with adaptive remeshing
 ```sh
-ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L0p2_unconfined_B.fold -fo Re100_unconfined_B -mo Re100_unconfined_B -adaptto bda -thetamax 1 -hmin 1e-5 -nf 1 -param S -param2 L -h0 4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 1e-3 -amax 90
-ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L0p2_unconfined_B.fold -fo Re100_unconfined_B_b2 -mo Re100_unconfined_B_b2 -adaptto bda -thetamax 1 -hmin 1e-5 -nf 1 -param S -param2 L -h0 -4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 1e-3 -amax 90
-ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L0p2_unconfined_F.fold -fo Re100_unconfined_F -mo Re100_unconfined_F -adaptto bda -thetamax 1 -hmin 1e-5 -nf 1 -param S -param2 L -h0 4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 1e-3 -amax 90
-ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L0p2_unconfined_F.fold -fo Re100_unconfined_F_b2 -mo Re100_unconfined_F_b2 -adaptto bda -thetamax 1 -hmin 1e-5 -nf 1 -param S -param2 L -h0 -4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 1e-3 -amax 90
+ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L0p2_unconfined_B.fold -fo Re100_unconfined_B -mo Re100_unconfined_B -adaptto bda -thetamax 1 -hmin 1e-5 -nf 1 -param S -param2 L -h0 4 -scount 5 -paramtarget 3 -param2target 1e-3 -amax 90
+ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L0p2_unconfined_B.fold -fo Re100_unconfined_B_b2 -mo Re100_unconfined_B_b2 -adaptto bda -thetamax 1 -hmin 1e-5 -nf 1 -param S -param2 L -h0 -4 -scount 5 -paramtarget 3 -param2target 1e-3 -amax 90
+ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L0p2_unconfined_F.fold -fo Re100_unconfined_F -mo Re100_unconfined_F -adaptto bda -thetamax 1 -hmin 1e-5 -nf 1 -param S -param2 L -h0 4 -scount 5 -paramtarget 3 -param2target 1e-3 -amax 90
+ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L0p2_unconfined_F.fold -fo Re100_unconfined_F_b2 -mo Re100_unconfined_F_b2 -adaptto bda -thetamax 1 -hmin 1e-5 -nf 1 -param S -param2 L -h0 -4 -scount 5 -paramtarget 3 -param2target 1e-3 -amax 90
 ```
 
 ## Computations for Figure 3 (weak axial confinement case)
 1. Continue base states along the parameter $S$ with adaptive remeshing
 ```sh
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L2_C4.base -fo Re100_L2_C4 -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L2_C4 -paramtarget 3 -hmin 1e-5
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L2_C8.base -fo Re100_L2_C8 -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L2_C8 -paramtarget 3 -hmin 1e-5
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L2_C16.base -fo Re100_L2_C16 -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L2_C16 -paramtarget 3 -hmin 1e-5
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L2_C40.base -fo Re100_L2_C40 -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L2_C40 -paramtarget 3 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L2_C4.base -fo Re100_L2_C4 -param S -h0 10 -scount 5 -mo Re100_L2_C4 -paramtarget 3 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L2_C8.base -fo Re100_L2_C8 -param S -h0 10 -scount 5 -mo Re100_L2_C8 -paramtarget 3 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L2_C16.base -fo Re100_L2_C16 -param S -h0 10 -scount 5 -mo Re100_L2_C16 -paramtarget 3 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L2_C40.base -fo Re100_L2_C40 -param S -h0 10 -scount 5 -mo Re100_L2_C40 -paramtarget 3 -hmin 1e-5
 ```
 
 2. Continue alternate branch of $C=16$ solutions
@@ -182,7 +182,7 @@ ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi $lastfile -fo Re100_S
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi Re100_S3_L2_C16.base -fo Re100_S3_L2_C16 -C 12 -snes_linesearch_type secant
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi Re100_S3_L2_C16.base -fo Re100_S3_L2_C16 -C 16 -snes_linesearch_type secant
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi Re100_S3_L2_C16.base -fo Re100_S3_L2_C16 -hmin 1e-5 -mo Re100_S3_L2_C16
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S3_L2_C16.base -fo Re100_L2_C16_b2 -param S -h0 -10 -scount 5 -maxcount -1 -mo Re100_L2_C16_b2 -paramtarget 3.01 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S3_L2_C16.base -fo Re100_L2_C16_b2 -param S -h0 -10 -scount 5 -mo Re100_L2_C16_b2 -paramtarget 3.01 -hmin 1e-5
 ```
 
 3. Compute backward and forward fold bifurcations from $C=8$ solution branch
@@ -196,8 +196,8 @@ ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi Re100_L2_C8_F.fold -f
 
 4. Continue the neutral fold curve in the $(S, C)$-plane with adaptive remeshing
 ```sh
-ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L2_C8_B.fold -fo Re100_L2_B -mo Re100_L2_B -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 -4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 1e-3 -amax 90
-ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L2_C8_B.fold -fo Re100_L2_B_b2 -mo Re100_L2_B_b2 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 1e-3 -amax 90
+ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L2_C8_B.fold -fo Re100_L2_B -mo Re100_L2_B -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 -4 -scount 5 -paramtarget 3 -param2target 1e-3 -amax 90
+ff-mpirun -np $nproc foldcontinue.md -v 0 -dir $workdir -fi Re100_L2_C8_B.fold -fo Re100_L2_B_b2 -mo Re100_L2_B_b2 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -paramtarget 3 -param2target 1e-3 -amax 90
 ```
 
 5. Compute the codimension-2 cusp bifurcation
@@ -238,28 +238,28 @@ ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi Re100_L2_S2p7.hopf -p
 
 7. Continue along the Hopf neutral curves
 ```sh
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C4.hopf -fo Re100_L2_C4 -mo Re100_L2_C4 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 3.99 -amax 90
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C4.hopf -fo Re100_L2_C4_b2 -mo Re100_L2_C4_b2 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 -4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 4.01 -amax 90
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C4.hopf -fo Re100_L2_C4 -mo Re100_L2_C4 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -paramtarget 3 -param2target 3.99 -amax 90
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C4.hopf -fo Re100_L2_C4_b2 -mo Re100_L2_C4_b2 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 -4 -scount 5 -paramtarget 3 -param2target 4.01 -amax 90
 
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C8.hopf -fo Re100_L2_C8 -mo Re100_L2_C8 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 7.99 -amax 90
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C8.hopf -fo Re100_L2_C8_b2 -mo Re100_L2_C8_b2 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 -4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 8.01 -amax 90
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C8.hopf -fo Re100_L2_C8 -mo Re100_L2_C8 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -paramtarget 3 -param2target 7.99 -amax 90
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C8.hopf -fo Re100_L2_C8_b2 -mo Re100_L2_C8_b2 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 -4 -scount 5 -paramtarget 3 -param2target 8.01 -amax 90
 
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C16.hopf -fo Re100_L2_C16 -mo Re100_L2_C16 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 15.99 -amax 90
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C16.hopf -fo Re100_L2_C16_b2 -mo Re100_L2_C16_b2 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 -4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 16.01 -amax 90
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C16.hopf -fo Re100_L2_C16 -mo Re100_L2_C16 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -paramtarget 3 -param2target 15.99 -amax 90
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_C16.hopf -fo Re100_L2_C16_b2 -mo Re100_L2_C16_b2 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 -4 -scount 5 -paramtarget 3 -param2target 16.01 -amax 90
 
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_S2p7.hopf -fo Re100_L2_S2p7 -mo Re100_L2_S2p7 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 1e-3 -amax 90
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_S2p7.hopf -fo Re100_L2_S2p7_b2 -mo Re100_L2_S2p7_b2 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 -4 -scount 5 -maxcount -1 -paramtarget 3 -param2target 1e-3 -amax 90
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_S2p7.hopf -fo Re100_L2_S2p7 -mo Re100_L2_S2p7 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -paramtarget 3 -param2target 1e-3 -amax 90
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_S2p7.hopf -fo Re100_L2_S2p7_b2 -mo Re100_L2_S2p7_b2 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 -4 -scount 5 -paramtarget 3 -param2target 1e-3 -amax 90
 
-ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_S3.hopf -fo Re100_L2_S3 -mo Re100_L2_S3 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -maxcount -1 -paramtarget 3.01 -param2target 1e-3 -amax 90
+ff-mpirun -np $nproc hopfcontinue.md -v 0 -dir $workdir -fi Re100_L2_S3.hopf -fo Re100_L2_S3 -mo Re100_L2_S3 -adaptto bda -hmin 1e-5 -nf 1 -param S -param2 C -h0 4 -scount 5 -paramtarget 3.01 -param2target 1e-3 -amax 90
 ```
 
 ## Computations for Figure 4 (strong axial confinement case)
 1. Continue base states along the parameter $S$ with adaptive remeshing
 ```sh
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0_C4.base -fo Re100_L0_C4 -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L0_C4 -paramtarget 3 -hmin 1e-5
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0_C8.base -fo Re100_L0_C8 -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L0_C8 -paramtarget 3 -hmin 1e-5
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0_C16.base -fo Re100_L0_C16 -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L0_C16 -paramtarget 3 -hmin 1e-5
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0_C40.base -fo Re100_L0_C40 -param S -h0 10 -scount 5 -maxcount -1 -mo Re100_L0_C40 -paramtarget 3 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0_C4.base -fo Re100_L0_C4 -param S -h0 10 -scount 5 -mo Re100_L0_C4 -paramtarget 3 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0_C8.base -fo Re100_L0_C8 -param S -h0 10 -scount 5 -mo Re100_L0_C8 -paramtarget 3 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0_C16.base -fo Re100_L0_C16 -param S -h0 10 -scount 5 -mo Re100_L0_C16 -paramtarget 3 -hmin 1e-5
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Re100_S0_L0_C40.base -fo Re100_L0_C40 -param S -h0 10 -scount 5 -mo Re100_L0_C40 -paramtarget 3 -hmin 1e-5
 ```
 
 (Continues similarly to the above)

--- a/examples/pralits_etal_2010/README.md
+++ b/examples/pralits_etal_2010/README.md
@@ -85,7 +85,7 @@ ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi cylinder_6.base -fo c
 
 4. Continue $Re=100$ base state along the parameter $\alpha$ with adaptive remeshing
 ```sh
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi cylinder100.base -fo cylinder100 -param alpha -h0 4 -scount 5 -maxcount 120 -mo cylinder100 -thetamax 1 -hmin 5e-3 -dmax 1 -err 0.005
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi cylinder100.base -fo cylinder100 -param alpha -h0 4 -scount 5 -paramtarget 7 -maxcount 120 -mo cylinder100 -thetamax 1 -hmin 5e-3 -dmax 1 -err 0.005
 ```
 NOTE: care should be taken to ensure that the continuation does not jump from one branch to another when the mesh is adapted within the multistable parameter region.
 

--- a/foldcontinue.md
+++ b/foldcontinue.md
@@ -46,10 +46,10 @@ int snesmaxit = getARGV("-snes_max_it", 10);
 string sneslinesearchtype = getARGV("-snes_linesearch_type", "none");
 real[string] alpha;
 real beta;
-real paramtarget = getARGV("-paramtarget",1.0);
-real param2target = getARGV("-param2target",1.0);
+real paramtarget = getARGV("-paramtarget",-1.0e30);
+real param2target = getARGV("-param2target",-1.0e30);
 real TGV = getARGV("-tgv", -1);
-bool stopflag = false;
+bool stopflag = (maxcount == 0);
 bool forcesave = false;
 
 // Load mesh, make FE basis
@@ -232,9 +232,8 @@ while (!stopflag){
   SNESSolve(Jaa, funcJa, funcRa, qa, convergence = funcConvergence, reason = ret,
             sparams = "-snes_linesearch_type " + sneslinesearchtype + " -options_left no -snes_converged_reason -snes_max_it " + snesmaxit); // solve nonlinear problem with SNES
   if (ret > 0) {
-    ++count;
-    if (maxcount > 0) stopflag = (count >= maxcount);
-    else if ((paramvals(0) - paramtarget)*paramdiff1 <= 0 || (paramvals(1) - param2target)*paramdiff2 <= 0) stopflag = true;
+    stopflag = (maxcount > 0)*(++count >= maxcount) || ((paramvals(0) - paramtarget)*paramdiff1 <= 0) 
+              || ((paramvals(1) - param2target)*paramdiff2 <= 0);
     h0 /= f;
     if (cosalpha < 0 && contorder > 0) {
       h0 *= -1.0;

--- a/hopfcontinue.md
+++ b/hopfcontinue.md
@@ -53,9 +53,9 @@ real[int] sym1(sym.n);
 real omega;
 complex[string] alpha;
 complex beta;
-real paramtarget = getARGV("-paramtarget",1.0);
-real param2target = getARGV("-param2target",1.0);
-bool stopflag = false;
+real paramtarget = getARGV("-paramtarget",-1.0e30);
+real param2target = getARGV("-param2target",-1.0e30);
+bool stopflag = (maxcount == 0);
 bool forcesave = false;
 
 // Load mesh, make FE basis
@@ -284,9 +284,8 @@ while (!stopflag){
   SNESSolve(Jaa, funcJa, funcRa, qa, convergence = funcConvergence, reason = ret,
             sparams = "-snes_linesearch_type " + sneslinesearchtype + " -options_left no -snes_converged_reason -snes_max_it " + snesmaxit); // solve nonlinear problem with SNES
   if (ret > 0) {
-    ++count;
-    if (maxcount > 0) stopflag = (count >= maxcount);
-    else if ((paramvals(0) - paramtarget)*paramdiff1 <= 0 || (paramvals(2-zerofreq) - param2target)*paramdiff2 <= 0) stopflag = true;
+    stopflag = (maxcount > 0)*(++count >= maxcount) || ((paramvals(0) - paramtarget)*paramdiff1 <= 0)
+              || ((paramvals(2-zerofreq) - param2target)*paramdiff2 <= 0);
     h0 /= f;
     if (cosalpha < 0 && contorder > 0) {
       h0 *= -1.0;

--- a/porbcontinue.md
+++ b/porbcontinue.md
@@ -47,10 +47,10 @@ string sneslinesearchtype = getARGV("-snes_linesearch_type", "none");
 int Nh = getARGV("-Nh", 0); //if 0, will read Nh from file. In practice, Nh must be at least 1, otherwise use basecompute.md
 int blocks = getARGV("-blocks", 1); //if blocks = 1, use monolithic LU; if blocks = N w/ 2 <= N <= Nh+1, use block preconditioner with N blocks
 int refactor = getARGV("-refact", snesmaxit);
-real paramtarget = getARGV("-paramtarget",1.0);
+real paramtarget = getARGV("-paramtarget",-1.0e30);
 real[int] sym0(sym.n);
 real omega;
-bool stopflag = false;
+bool stopflag = (maxcount == 0);
 bool forcesave = false;
 
 // Load mesh, make FE basis
@@ -283,9 +283,7 @@ while (!stopflag){
   SNESSolve(JHBaa, funcJa, funcRa, qa, convergence = funcConvergence, reason = ret,
             sparams = "-snes_linesearch_type " + sneslinesearchtype + " -snes_converged_reason -options_left no -snes_max_it " + snesmaxit); // solve nonlinear problem with SNES
   if (ret > 0) {
-    ++count;
-    if (maxcount > 0) stopflag = (count >= maxcount);
-    else if ((paramvals(1-zerofreq) - paramtarget)*paramdiff <= 0) stopflag = true;
+    stopflag = (maxcount > 0)*(++count >= maxcount) || ((paramvals(1-zerofreq) - paramtarget)*paramdiff <= 0);
     h0 /= f;
     if (cosalpha < 0 && contorder > 0) {
       h0 *= -1.0;


### PR DESCRIPTION
Allows setting `maxcount` alongside `paramtarget` so that either ends continuation.
Also allows setting `maxcount = 0` to write to `*.stat` files without performing continuation. 